### PR TITLE
add license header check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,16 @@ jobs:
       - name: Format
         run: |
           bash scripts/format.sh
+
+  LicenseCheck:
+    name: License Check
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Check License Header
+        uses: apache/skywalking-eyes@985866ce7e324454f61e22eb2db2e998db09d6f3

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,13 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'dist'
+    - 'licenses'
+    - '**/*.md'
+    - 'LICENSE'
+    - 'NOTICE'
+
+  comment: never


### PR DESCRIPTION
https://github.com/apache/skywalking-eyes

Right now this is configured as recommended for Apache projects in the skywalking-eyes readme.

As for automatic fixing of the headers, I think the options with skywalking-eyes are to either configure this CI job to make a new commit adding the license headers (https://github.com/apache/skywalking-eyes#using-the-action-in-fix-mode), or run the tool in fix mode in our format script or pre-commit setup (which would require either installation or docker). Any preferences?