### PR TITLE
Initial Ray runner prototype based on FnApiRunner in Beam

### DIFF
--- a/ray_beam_runner/portability/__init__.py
+++ b/ray_beam_runner/portability/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/ray_beam_runner/portability/context_management.py
+++ b/ray_beam_runner/portability/context_management.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 import typing
 from typing import List
 from typing import Optional

--- a/ray_beam_runner/portability/context_management.py
+++ b/ray_beam_runner/portability/context_management.py
@@ -1,0 +1,109 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import List
+from typing import Optional
+
+from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.portability.api import endpoints_pb2
+from apache_beam.runners.portability.fn_api_runner import execution as fn_execution
+from apache_beam.runners.portability.fn_api_runner import translations
+from apache_beam.runners.portability.fn_api_runner import worker_handlers
+from apache_beam.runners.worker import bundle_processor
+from apache_beam.utils import proto_utils
+
+from ray_beam_runner.portability.execution import RayRunnerExecutionContext
+
+class RayBundleContextManager(fn_execution.BundleContextManager):
+
+  def __init__(self,
+      execution_context: RayRunnerExecutionContext,
+      stage: translations.Stage,
+  ) -> None:
+    super(RayBundleContextManager, self).__init__(execution_context, stage, None)
+
+  @property
+  def worker_handlers(self) -> List[worker_handlers.WorkerHandler]:
+    return []
+
+  def data_api_service_descriptor(self) -> Optional[endpoints_pb2.ApiServiceDescriptor]:
+    return endpoints_pb2.ApiServiceDescriptor(url='fake')
+
+  def state_api_service_descriptor(self) -> Optional[endpoints_pb2.ApiServiceDescriptor]:
+    return None
+
+  @property
+  def process_bundle_descriptor(self):
+    # type: () -> beam_fn_api_pb2.ProcessBundleDescriptor
+    if self._process_bundle_descriptor is None:
+      self._process_bundle_descriptor = self._build_process_bundle_descriptor()
+      self._timer_coder_ids = self._build_timer_coders_id_map()
+    return self._process_bundle_descriptor
+
+  def extract_bundle_inputs_and_outputs(self):
+    # type: () -> Tuple[Dict[str, PartitionableBuffer], DataOutput, Dict[TimerFamilyId, bytes]]
+
+    """Returns maps of transform names to PCollection identifiers.
+
+    Also mutates IO stages to point to the data ApiServiceDescriptor.
+
+    Returns:
+      A tuple of (data_input, data_output, expected_timer_output) dictionaries.
+        `data_input` is a dictionary mapping (transform_name, output_name) to a
+        PCollection buffer; `data_output` is a dictionary mapping
+        (transform_name, output_name) to a PCollection ID.
+        `expected_timer_output` is a dictionary mapping transform_id and
+        timer family ID to a buffer id for timers.
+    """
+    data_input = {}  # type: Dict[str, PartitionableBuffer]
+    data_output = {}  # type: DataOutput
+    # A mapping of {(transform_id, timer_family_id) : buffer_id}
+    expected_timer_output = {}  # type: OutputTimers
+    for transform in self.stage.transforms:
+      if transform.spec.urn in (bundle_processor.DATA_INPUT_URN,
+                                bundle_processor.DATA_OUTPUT_URN):
+        pcoll_id = transform.spec.payload
+        if transform.spec.urn == bundle_processor.DATA_INPUT_URN:
+          coder_id = self.execution_context.data_channel_coders[translations.only_element(
+              transform.outputs.values())]
+          coder = self.execution_context.pipeline_context.coders[
+            self.execution_context.safe_coders.get(coder_id, coder_id)]
+          if pcoll_id == translations.IMPULSE_BUFFER:
+            data_input[transform.unique_name] = fn_execution.ListBuffer(
+                coder_impl=coder.get_impl())
+            data_input[transform.unique_name].append(fn_execution.ENCODED_IMPULSE_VALUE)
+          else:
+            # TODO(pabloem): We need to retrieve the input data from data.
+            data_input[transform.unique_name] = fn_execution.ListBuffer(
+                coder_impl=coder.get_impl())
+        elif transform.spec.urn == bundle_processor.DATA_OUTPUT_URN:
+          data_output[transform.unique_name] = pcoll_id
+          coder_id = self.execution_context.data_channel_coders[translations.only_element(
+              transform.inputs.values())]
+        else:
+          raise NotImplementedError
+        data_spec = beam_fn_api_pb2.RemoteGrpcPort(coder_id=coder_id)
+        data_spec.api_service_descriptor.url = 'fake'
+        transform.spec.payload = data_spec.SerializeToString()
+      elif transform.spec.urn in translations.PAR_DO_URNS:
+        payload = proto_utils.parse_Bytes(
+            transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
+        for timer_family_id in payload.timer_family_specs.keys():
+          expected_timer_output[(transform.unique_name, timer_family_id)] = (
+              translations.create_buffer_id(timer_family_id, 'timers'))
+    return data_input, data_output, expected_timer_output

--- a/ray_beam_runner/portability/execution.py
+++ b/ray_beam_runner/portability/execution.py
@@ -333,7 +333,7 @@ class RayWatermarkManager(watermark_manager.WatermarkManager):
     if self._initialized:
       return
     logging.info('initialized the RayWatermarkManager')
-    watermark_manager.WatermarkManager.setup(self, stages)
+    watermark_manager.WatermarkManager.__init__(self, stages)
     self._initialized = True
 
 

--- a/ray_beam_runner/portability/execution.py
+++ b/ray_beam_runner/portability/execution.py
@@ -1,0 +1,107 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Set of utilities for execution of a pipeline by the FnApiRunner."""
+
+# mypy: disallow-untyped-defs
+
+import contextlib
+import collections
+from typing import Iterator
+from typing import Optional
+from typing import Tuple
+
+import ray
+
+from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.runners.worker import sdk_worker
+
+
+@ray.remote
+class _ActorStateManager:
+  def __init__(self):
+    self._data = collections.defaultdict(lambda : [])
+
+  def get_raw(
+      self,
+      bundle_id: str,
+      state_key: str,
+      continuation_token: Optional[bytes] = None,
+  ) -> Tuple[bytes, Optional[bytes]]:
+    if continuation_token:
+      continuation_token = int(continuation_token)
+    else:
+      continuation_token = 0
+
+    new_cont_token = continuation_token + 1
+    if len(self._data[(bundle_id, state_key)]) == new_cont_token:
+      return self._data[(bundle_id, state_key)][continuation_token], None
+    else:
+      return (self._data[(bundle_id, state_key)][continuation_token],
+              str(continuation_token + 1).encode('utf8'))
+
+  def append_raw(
+      self,
+      bundle_id: str,
+      state_key: str,
+      data: bytes
+  ):
+    self._data[(bundle_id, state_key)].append(data)
+
+  def clear(self, bundle_id: str, state_key: str):
+    self._data[(bundle_id, state_key)] = []
+
+
+class RayStateManager(sdk_worker.StateHandler):
+  def __init__(self, state_actor: Optional[_ActorStateManager] = None):
+    self._state_actor = state_actor or _ActorStateManager.remote()
+    self._instruction_id: Optional[str] = None
+
+  @staticmethod
+  def _to_key(state_key: beam_fn_api_pb2.StateKey):
+    return state_key.SerializeToString()
+
+  def get_raw(
+      self,
+      state_key,  # type: beam_fn_api_pb2.StateKey
+      continuation_token=None  # type: Optional[bytes]
+  ) -> Tuple[bytes, Optional[bytes]]:
+    assert self._instruction_id is not None
+    return ray.get(
+        self._state_actor.get_raw.remote(self._instruction_id, RayStateManager._to_key(state_key), continuation_token))
+
+  def append_raw(
+      self,
+      state_key: beam_fn_api_pb2.StateKey,
+      data: bytes
+  ) -> sdk_worker._Future:
+    assert self._instruction_id is not None
+    return self._state_actor.append_raw.remote(self._instruction_id, RayStateManager._to_key(state_key), data)
+
+  def clear(self, state_key: beam_fn_api_pb2.StateKey) -> sdk_worker._Future:
+    # TODO(pabloem): Does the ray future work as a replacement of Beam _Future?
+    assert self._instruction_id is not None
+    return self._state_actor.clear.remote(self._instruction_id, RayStateManager._to_key(state_key))
+
+  @contextlib.contextmanager
+  def process_instruction_id(self, bundle_id: str) -> Iterator[None]:
+    self._instruction_id = bundle_id
+    yield
+    self._instruction_id = None
+
+  def done(self):
+    pass

--- a/ray_beam_runner/portability/execution.py
+++ b/ray_beam_runner/portability/execution.py
@@ -21,14 +21,167 @@
 
 import contextlib
 import collections
+import copy
+import logging
 from typing import Iterator
+from typing import List
+from typing import Mapping
+from typing import MutableMapping
 from typing import Optional
 from typing import Tuple
 
 import ray
 
+from apache_beam.portability import common_urns
 from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners import pipeline_context
+from apache_beam.runners.portability.fn_api_runner import execution as fn_execution
+from apache_beam.runners.portability.fn_api_runner import translations
+from apache_beam.runners.portability.fn_api_runner import watermark_manager
+from apache_beam.runners.portability.fn_api_runner import worker_handlers
+from apache_beam.runners.worker import bundle_processor
 from apache_beam.runners.worker import sdk_worker
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def ray_execute_bundle(
+    runner_context: 'RayRunnerExecutionContext',
+    bundle_context_manager: fn_execution.BundleContextManager,
+    state_handler: sdk_worker.StateHandler,
+    inputs: Mapping[str, fn_execution.PartitionableBuffer],
+    fired_timers: Mapping[translations.TimerFamilyId, fn_execution.PartitionableBuffer],
+    expected_outputs: translations.DataOutput,
+    expected_output_timers: Mapping[translations.TimerFamilyId, bytes],
+    instruction_request: beam_fn_api_pb2.InstructionRequest,
+    dry_run=False,
+) -> Tuple[beam_fn_api_pb2.InstructionResponse, Mapping[bytes, fn_execution.PartitionableBuffer]]:
+  output_buffers = {}
+  process_bundle_id = instruction_request.instruction_id
+
+  worker_handler: worker_handlers.WorkerHandler = worker_handlers.EmbeddedWorkerHandler(
+      None, # Unnecessary payload.
+      state_handler,
+      None, # Unnecessary provision info.
+      runner_context.worker_manager,
+  )
+
+  for transform_id, timer_family_id in expected_output_timers.keys():
+    timer_out = worker_handler.data_conn.output_timer_stream(
+        process_bundle_id, transform_id, timer_family_id)
+    for timer in fired_timers.get((transform_id, timer_family_id), []):
+      timer_out.write(timer)
+    timer_out.close()
+
+  for transform_id, elements in inputs.items():
+    data_out = worker_handler.data_conn.output_stream(
+        process_bundle_id, transform_id)
+    for byte_stream in elements:
+      data_out.write(byte_stream)
+    data_out.close()
+
+  expect_reads = list(
+      expected_outputs.keys())  # type: List[Union[str, Tuple[str, str]]]
+  expect_reads.extend(list(expected_output_timers.keys()))
+
+  result_future = worker_handler.control_conn.push(instruction_request)
+
+  # Gather all output data.
+  for output in worker_handler.data_conn.input_elements(
+      process_bundle_id,
+      expect_reads,
+      abort_callback=lambda:
+      (result_future.is_done() and bool(result_future.get().error))):
+    if isinstance(output, beam_fn_api_pb2.Elements.Timers) and not dry_run:
+      timer_buffer = _get_buffer(
+          runner_context,
+          bundle_context_manager,
+          expected_output_timers[(
+              output.transform_id, output.timer_family_id)],
+          output.transform_id,
+          output_buffers)
+      if timer_buffer.cleared:
+        timer_buffer.reset()
+      timer_buffer.append(output.timers)
+    if isinstance(output, beam_fn_api_pb2.Elements.Data) and not dry_run:
+      _get_buffer(
+          runner_context,
+          bundle_context_manager,
+          expected_outputs[output.transform_id],
+          output.transform_id,
+          output_buffers).append(output.data)
+
+  _LOGGER.debug('Wait for the bundle %s to finish.' % process_bundle_id)
+  return result_future.get(), output_buffers
+
+
+def _get_buffer(
+    runner_context: 'RayRunnerExecutionContext',
+    bundle_context_manager: fn_execution.BundleContextManager,
+    buffer_id: bytes,
+    transform_id: str,
+    output_buffers: MutableMapping[bytes, fn_execution.PartitionableBuffer]):
+  kind, name = translations.split_buffer_id(buffer_id)
+  if kind == 'materialize':
+    if buffer_id not in output_buffers:
+      coder_id = beam_fn_api_pb2.RemoteGrpcPort.FromString(
+          bundle_context_manager.process_bundle_descriptor.transforms[transform_id].spec.payload
+      ).coder_id
+      input_coder_impl = _get_coder_impl(coder_id, runner_context)
+      output_buffers[buffer_id] = fn_execution.ListBuffer(input_coder_impl)
+    return output_buffers[buffer_id]
+  elif kind == 'timers':
+    # For timer buffer, name = timer_family_id
+    if buffer_id not in output_buffers:
+      timer_coder_impl = _get_coder_impl(bundle_context_manager._timer_coder_ids[(transform_id, name)], runner_context)
+      output_buffers[buffer_id] = fn_execution.ListBuffer(timer_coder_impl)
+    return output_buffers[buffer_id]
+  elif kind == 'group':
+    if buffer_id not in output_buffers:
+      original_gbk_transform = name
+      transform_proto = runner_context.pipeline_components.transforms[
+        original_gbk_transform]
+      input_pcoll = translations.only_element(list(transform_proto.inputs.values()))
+      output_pcoll = translations.only_element(list(transform_proto.outputs.values()))
+      pre_gbk_coder = runner_context.pipeline_context.coders[
+        runner_context.safe_coders[
+          runner_context.data_channel_coders[input_pcoll]]]
+      post_gbk_coder = runner_context.pipeline_context.coders[
+        runner_context.safe_coders[
+          runner_context.data_channel_coders[output_pcoll]]]
+      windowing_strategy = (
+          runner_context.pipeline_context.windowing_strategies[
+            runner_context.safe_windowing_strategies[
+              runner_context.pipeline_components.
+                pcollections[input_pcoll].windowing_strategy_id]])
+      output_buffers[buffer_id] = fn_execution.GroupingBuffer(
+          pre_gbk_coder, post_gbk_coder, windowing_strategy)
+    return output_buffers[buffer_id]
+  else:
+    raise ValueError('Unknown kind: %s' % kind)
+
+def _get_coder_impl(coder_id, execution_context: 'RayRunnerExecutionContext'):
+  if coder_id in execution_context.safe_coders:
+    return execution_context.pipeline_context.coders[
+      execution_context.safe_coders[coder_id]].get_impl()
+  else:
+    return execution_context.pipeline_context.coders[coder_id].get_impl()
+
+
+class _RayMetricsActor:
+  def __init__(self):
+    self._metrics = {}
+
+
+@ray.remote
+class _RayRunnerStats:
+  def __init__(self):
+    self._bundle_uid = 0
+
+  def next_bundle(self):
+    self._bundle_uid += 1
+    return self._bundle_uid
 
 
 @ray.remote
@@ -105,3 +258,116 @@ class RayStateManager(sdk_worker.StateHandler):
 
   def done(self):
     pass
+
+
+class RayWorkerHandlerManager:
+  def __init__(self):
+    self._process_bundle_descriptors = {}
+
+  def register_process_bundle_descriptor(self, process_bundle_descriptor: beam_fn_api_pb2.ProcessBundleDescriptor):
+    self._process_bundle_descriptors[process_bundle_descriptor.id] = process_bundle_descriptor
+
+
+class RayRunnerExecutionContext(object):
+  def __init__(self,
+      stages: List[translations.Stage],
+      pipeline_components: beam_runner_api_pb2.Components,
+      safe_coders: translations.SafeCoderMapping,
+      data_channel_coders: Mapping[str, str],
+  ) -> None:
+    """
+    :param pipeline_components:  (beam_runner_api_pb2.Components)
+    :param safe_coders: A map from Coder ID to Safe Coder ID.
+    :param data_channel_coders: A map from PCollection ID to the ID of the Coder
+        for that PCollection.
+    """
+    self.state_servicer = RayStateManager()
+    self.stages = stages
+    self.side_input_descriptors_by_stage = (
+        fn_execution.FnApiRunnerExecutionContext._build_data_side_inputs_map(stages))
+    self.pipeline_components = pipeline_components
+    self.safe_coders = safe_coders
+    self.data_channel_coders = data_channel_coders
+
+    self.input_transform_to_buffer_id = {
+        t.unique_name: t.spec.payload
+        for s in stages for t in s.transforms
+        if t.spec.urn == bundle_processor.DATA_INPUT_URN
+    }
+    self.watermark_manager = watermark_manager.WatermarkManager(stages)
+    self.pipeline_context = pipeline_context.PipelineContext(
+        self.pipeline_components,
+        iterable_state_write=False)
+    self.safe_windowing_strategies = {
+        id: self._make_safe_windowing_strategy(id)
+        for id in self.pipeline_components.windowing_strategies.keys()
+    }
+    self.stats = _RayRunnerStats.remote()
+    self.worker_manager = RayWorkerHandlerManager()
+
+  def next_uid(self) -> str:
+    return str(ray.get(self.stats.next_bundle.remote()))
+
+  def _make_safe_windowing_strategy(self, id):
+    # type: (str) -> str
+    windowing_strategy_proto = self.pipeline_components.windowing_strategies[id]
+    if windowing_strategy_proto.window_fn.urn in fn_execution.SAFE_WINDOW_FNS:
+      return id
+    else:
+      safe_id = id + '_safe'
+      while safe_id in self.pipeline_components.windowing_strategies:
+        safe_id += '_'
+      safe_proto = copy.copy(windowing_strategy_proto)
+      if (windowing_strategy_proto.merge_status ==
+          beam_runner_api_pb2.MergeStatus.NON_MERGING):
+        safe_proto.window_fn.urn = fn_execution.GenericNonMergingWindowFn.URN
+        safe_proto.window_fn.payload = (
+            windowing_strategy_proto.window_coder_id.encode('utf-8'))
+      elif (windowing_strategy_proto.merge_status ==
+            beam_runner_api_pb2.MergeStatus.NEEDS_MERGE):
+        window_fn = fn_execution.GenericMergingWindowFn(self, windowing_strategy_proto)
+        safe_proto.window_fn.urn = fn_execution.GenericMergingWindowFn.URN
+        safe_proto.window_fn.payload = window_fn.payload()
+      else:
+        raise NotImplementedError(
+            'Unsupported merging strategy: %s' %
+            windowing_strategy_proto.merge_status)
+      self.pipeline_context.windowing_strategies.put_proto(safe_id, safe_proto)
+      return safe_id
+
+  def commit_side_inputs_to_state(
+      self,
+      data_side_input,  # type: DataSideInput
+  ):
+    # type: (...) -> None
+    for (consuming_transform_id, tag), (buffer_id,
+                                        func_spec) in data_side_input.items():
+      _, pcoll_id = translations.split_buffer_id(buffer_id)
+      value_coder = self.pipeline_context.coders[self.safe_coders[
+        self.data_channel_coders[pcoll_id]]]
+      elements_by_window = fn_execution.WindowGroupingBuffer(func_spec, value_coder)
+      if buffer_id not in self.pcoll_buffers:
+        self.pcoll_buffers[buffer_id] = fn_execution.ListBuffer(
+            coder_impl=value_coder.get_impl())
+      for element_data in self.pcoll_buffers[buffer_id]:
+        elements_by_window.append(element_data)
+
+      if func_spec.urn == common_urns.side_inputs.ITERABLE.urn:
+        for _, window, elements_data in elements_by_window.encoded_items():
+          state_key = beam_fn_api_pb2.StateKey(
+              iterable_side_input=beam_fn_api_pb2.StateKey.IterableSideInput(
+                  transform_id=consuming_transform_id,
+                  side_input_id=tag,
+                  window=window))
+          self.state_servicer.append_raw(state_key, elements_data)
+      elif func_spec.urn == common_urns.side_inputs.MULTIMAP.urn:
+        for key, window, elements_data in elements_by_window.encoded_items():
+          state_key = beam_fn_api_pb2.StateKey(
+              multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
+                  transform_id=consuming_transform_id,
+                  side_input_id=tag,
+                  window=window,
+                  key=key))
+          self.state_servicer.append_raw(state_key, elements_data)
+      else:
+        raise ValueError("Unknown access pattern: '%s'" % func_spec.urn)

--- a/ray_beam_runner/portability/execution.py
+++ b/ray_beam_runner/portability/execution.py
@@ -24,7 +24,7 @@ import collections
 import logging
 import random
 import typing
-from typing import Iterator, Tuple, Any, List
+from typing import Iterator, Any
 from typing import List
 from typing import Mapping
 from typing import Optional

--- a/ray_beam_runner/portability/execution.py
+++ b/ray_beam_runner/portability/execution.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""Set of utilities for execution of a pipeline by the FnApiRunner."""
+"""Set of utilities for execution of a pipeline by the RayRunner."""
 
 # mypy: disallow-untyped-defs
 

--- a/ray_beam_runner/portability/execution_test.py
+++ b/ray_beam_runner/portability/execution_test.py
@@ -1,0 +1,42 @@
+import hamcrest as hc
+import unittest
+
+import ray
+
+import apache_beam.portability.api.beam_fn_api_pb2
+from ray_beam_runner.portability.execution import RayStateManager
+
+class StateHandlerTest(unittest.TestCase):
+  SAMPLE_STATE_KEY = apache_beam.portability.api.beam_fn_api_pb2.StateKey()
+  SAMPLE_INPUT_DATA = [
+      b'bobby'
+      b'tables',
+      b'drop table',
+      b'where table_name > 12345'
+  ]
+
+  @classmethod
+  def setUpClass(cls) -> None:
+    if not ray.is_initialized():
+      ray.init()
+
+  @classmethod
+  def tearDownClass(cls) -> None:
+    ray.shutdown()
+
+  def test_data_stored_properly(self):
+    sh = RayStateManager()
+    with sh.process_instruction_id('anyinstruction'):
+      for data in StateHandlerTest.SAMPLE_INPUT_DATA:
+        sh.append_raw(StateHandlerTest.SAMPLE_STATE_KEY, data)
+
+    with sh.process_instruction_id('anyinstruction'):
+      continuation_token = None
+      all_data = []
+      while True:
+        data, continuation_token = sh.get_raw(StateHandlerTest.SAMPLE_STATE_KEY, continuation_token)
+        all_data.append(data)
+        if continuation_token is None:
+          break
+
+    hc.assert_that(all_data, hc.contains_exactly(*StateHandlerTest.SAMPLE_INPUT_DATA))

--- a/ray_beam_runner/portability/ray_fn_runner.py
+++ b/ray_beam_runner/portability/ray_fn_runner.py
@@ -1,0 +1,594 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A PipelineRunner using the SDK harness.
+"""
+# pytype: skip-file
+# mypy: check-untyped-defs
+
+import copy
+import itertools
+import logging
+from typing import TYPE_CHECKING
+from typing import Dict
+from typing import List
+from typing import Mapping
+from typing import MutableMapping
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Union
+
+from apache_beam.coders.coder_impl import create_OutputStream
+from apache_beam.metrics import metric
+from apache_beam.metrics import monitoring_infos
+from apache_beam.metrics.execution import MetricsContainer
+from apache_beam.metrics.metricbase import MetricName
+from apache_beam.options import pipeline_options
+from apache_beam.options.value_provider import RuntimeValueProvider
+from apache_beam.portability import common_urns
+from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners import runner
+from apache_beam.runners.common import group_by_key_input_visitor
+from apache_beam.runners.portability.fn_api_runner import execution
+from apache_beam.runners.portability.fn_api_runner import fn_runner
+from apache_beam.runners.portability.fn_api_runner import translations
+from apache_beam.runners.portability.fn_api_runner.execution import ListBuffer
+from apache_beam.runners.portability.fn_api_runner.translations import create_buffer_id
+from apache_beam.runners.portability.fn_api_runner.translations import only_element
+from apache_beam.runners.worker import bundle_processor
+from apache_beam.transforms import environments
+from apache_beam.utils import timestamp
+
+import ray
+from ray_beam_runner.portability.context_management import RayBundleContextManager
+from ray_beam_runner.portability.execution import _RayMetricsActor
+from ray_beam_runner.portability.execution import ray_execute_bundle
+from ray_beam_runner.portability.execution import RayRunnerExecutionContext
+
+if TYPE_CHECKING:
+  from apache_beam.pipeline import Pipeline
+  from apache_beam.portability.api import metrics_pb2
+
+_LOGGER = logging.getLogger(__name__)
+
+# This module is experimental. No backwards-compatibility guarantees.
+
+
+class RayFnApiRunner(runner.PipelineRunner):
+
+  NUM_FUSED_STAGES_COUNTER = "__num_fused_stages"
+
+  def __init__(
+      self,
+      progress_request_frequency: Optional[float] = None,
+  ) -> None:
+
+    """Creates a new Ray Runner instance.
+
+    Args:
+      progress_request_frequency: The frequency (in seconds) that the runner
+          waits before requesting progress from the SDK.
+    """
+    super().__init__()
+    # The default environment is actually a Ray environment.
+    self._default_environment = environments.EmbeddedPythonEnvironment.default()
+    self._progress_frequency = progress_request_frequency
+    self._cache_token_generator = fn_runner.FnApiRunner.get_cache_token_generator()
+
+  @staticmethod
+  def supported_requirements():
+    # type: () -> Tuple[str, ...]
+    return (
+        common_urns.requirements.REQUIRES_STATEFUL_PROCESSING.urn,
+        common_urns.requirements.REQUIRES_BUNDLE_FINALIZATION.urn,
+        common_urns.requirements.REQUIRES_SPLITTABLE_DOFN.urn,
+    )
+
+  def run_pipeline(self,
+                   pipeline,  # type: Pipeline
+                   options  # type: pipeline_options.PipelineOptions
+                  ):
+    # type: (...) -> RayRunnerResult
+    RuntimeValueProvider.set_runtime_options({})
+
+    # Setup "beam_fn_api" experiment options if lacked.
+    experiments = (
+        options.view_as(pipeline_options.DebugOptions).experiments or [])
+    if not 'beam_fn_api' in experiments:
+      experiments.append('beam_fn_api')
+    options.view_as(pipeline_options.DebugOptions).experiments = experiments
+
+    # This is sometimes needed if type checking is disabled
+    # to enforce that the inputs (and outputs) of GroupByKey operations
+    # are known to be KVs.
+    pipeline.visit(
+        group_by_key_input_visitor(
+            not options.view_as(pipeline_options.TypeOptions).
+            allow_non_deterministic_key_coders))
+
+    self._latest_run_result = self.run_via_runner_api(
+        pipeline.to_runner_api(default_environment=self._default_environment))
+    return self._latest_run_result
+
+  def run_via_runner_api(self, pipeline_proto):
+    # type: (beam_runner_api_pb2.Pipeline) -> RayRunnerResult
+    fn_runner.FnApiRunner._validate_requirements(None, pipeline_proto)
+
+    # TODO(pabloem): Implement _check_requirements once RayRunner implements
+    #    its own set of features.
+    fn_runner.FnApiRunner._check_requirements(self, pipeline_proto)
+    stage_context, stages = self.create_stages(pipeline_proto)
+    return self.run_stages(stage_context, stages)
+
+  def create_stages(
+      self,
+      pipeline_proto  # type: beam_runner_api_pb2.Pipeline
+  ):
+    # type: (...) -> Tuple[translations.TransformContext, List[translations.Stage]]
+    return translations.create_and_optimize_stages(
+        copy.deepcopy(pipeline_proto),
+        phases=[
+            translations.annotate_downstream_side_inputs,
+            translations.fix_side_input_pcoll_coders,
+            translations.pack_combiners,
+            translations.lift_combiners,
+            translations.expand_sdf,
+            translations.expand_gbk,
+            translations.sink_flattens,
+            translations.greedily_fuse,
+            translations.read_to_impulse,
+            translations.impulse_to_input,
+            translations.sort_stages,
+            translations.setup_timer_mapping,
+            translations.populate_data_channel_coders,
+        ],
+        known_runner_urns=frozenset([
+            common_urns.primitives.FLATTEN.urn,
+            common_urns.primitives.GROUP_BY_KEY.urn,
+        ]),
+        use_state_iterables=False,
+        is_drain=False)
+
+  def run_stages(self,
+                 stage_context,  # type: translations.TransformContext
+                 stages  # type: List[translations.Stage]
+                ):
+    # type: (...) -> RayRunnerResult
+
+    """Run a list of topologically-sorted stages in batch mode.
+
+    Args:
+      stage_context (translations.TransformContext)
+      stages (list[fn_api_runner.translations.Stage])
+    """
+    pipeline_metrics = MetricsContainer('')
+    pipeline_metrics.get_counter(
+        MetricName(
+            str(type(self)),
+            self.NUM_FUSED_STAGES_COUNTER,
+            urn='internal:' + self.NUM_FUSED_STAGES_COUNTER)).update(
+                len(stages))
+    monitoring_infos_by_stage = {}
+
+    runner_execution_context = RayRunnerExecutionContext(
+        stages,
+        stage_context.components,
+        stage_context.safe_coders,
+        stage_context.data_channel_coders)
+
+    try:
+      for stage in stages:
+        bundle_context_manager = RayBundleContextManager(
+            runner_execution_context, stage)
+        # bundle_context_manager._worker_handlers = [
+        #     worker_handlers.EmbeddedWorkerHandler(
+        #         None, # Unnecessary payload.
+        #         runner_execution_context.state_servicer,
+        #         None, # Unnecessary provision info.
+        #         runner_execution_context.worker_manager,
+        #     )
+        # ]
+
+        assert (
+            runner_execution_context.watermark_manager.get_stage_node(
+                bundle_context_manager.stage.name
+            ).input_watermark() == timestamp.MAX_TIMESTAMP), (
+            'wrong watermark for %s. Expected %s, but got %s.' % (
+                runner_execution_context.watermark_manager.get_stage_node(
+                    bundle_context_manager.stage.name),
+                timestamp.MAX_TIMESTAMP,
+                runner_execution_context.watermark_manager.get_stage_node(
+                    bundle_context_manager.stage.name
+                ).input_watermark()
+            )
+        )
+
+        stage_results = self._run_stage(
+            runner_execution_context, bundle_context_manager)
+
+        assert (
+            runner_execution_context.watermark_manager.get_stage_node(
+                bundle_context_manager.stage.name
+            ).input_watermark() == timestamp.MAX_TIMESTAMP), (
+            'wrong input watermark for %s. Expected %s, but got %s.' % (
+            runner_execution_context.watermark_manager.get_stage_node(
+                bundle_context_manager.stage.name),
+            timestamp.MAX_TIMESTAMP,
+            runner_execution_context.watermark_manager.get_stage_node(
+                bundle_context_manager.stage.name
+            ).output_watermark())
+        )
+
+        monitoring_infos_by_stage[stage.name] = (
+            list(stage_results.process_bundle.monitoring_infos))
+
+      monitoring_infos_by_stage[''] = list(
+          pipeline_metrics.to_runner_api_monitoring_infos('').values())
+    finally:
+      pass
+    return RayRunnerResult(runner.PipelineState.DONE, monitoring_infos_by_stage)
+
+  @staticmethod
+  def _collect_written_timers(
+      bundle_context_manager: execution.BundleContextManager,
+      output_buffers: Mapping[bytes, execution.PartitionableBuffer],
+  ) -> Tuple[Dict[translations.TimerFamilyId, timestamp.Timestamp],
+             Dict[translations.TimerFamilyId, ListBuffer]]:
+    """Review output buffers, and collect written timers.
+
+    This function reviews a stage that has just been run. The stage will have
+    written timers to its output buffers. The function then takes the timers,
+    and adds them to the `newly_set_timers` dictionary, and the
+    timer_watermark_data dictionary.
+
+    The function then returns the following two elements in a tuple:
+    - timer_watermark_data: A dictionary mapping timer family to upcoming
+        timestamp to fire.
+    - newly_set_timers: A dictionary mapping timer family to timer buffers
+        to be passed to the SDK upon firing.
+    """
+    timer_watermark_data = {}
+    newly_set_timers = {}
+    print(list(output_buffers.keys()))
+    for (transform_id, timer_family_id) in bundle_context_manager.stage.timers:
+      print('transf timerfam ' + str((transform_id, timer_family_id)))
+      written_timers = output_buffers.get(
+        create_buffer_id(timer_family_id, kind='timers'), None)
+      if not written_timers:
+        written_timers = execution.ListBuffer(None)
+        written_timers.clear()
+      assert isinstance(written_timers, ListBuffer)
+      timer_coder_impl = bundle_context_manager.get_timer_coder_impl(
+          transform_id, timer_family_id)
+      if not written_timers.cleared:
+        timers_by_key_and_window = {}
+        for elements_timers in written_timers:
+          for decoded_timer in timer_coder_impl.decode_all(elements_timers):
+            timers_by_key_and_window[decoded_timer.user_key,
+                                     decoded_timer.windows[0]] = decoded_timer
+        out = create_OutputStream()
+        for decoded_timer in timers_by_key_and_window.values():
+          # Only add not cleared timer to fired timers.
+          if not decoded_timer.clear_bit:
+            timer_coder_impl.encode_to_stream(decoded_timer, out, True)
+            if (transform_id, timer_family_id) not in timer_watermark_data:
+              timer_watermark_data[(transform_id,
+                                    timer_family_id)] = timestamp.MAX_TIMESTAMP
+            timer_watermark_data[(transform_id, timer_family_id)] = min(
+                timer_watermark_data[(transform_id, timer_family_id)],
+                decoded_timer.hold_timestamp)
+        newly_set_timers[(transform_id, timer_family_id)] = ListBuffer(
+            coder_impl=timer_coder_impl)
+        newly_set_timers[(transform_id, timer_family_id)].append(out.get())
+        written_timers.clear()
+
+    return timer_watermark_data, newly_set_timers
+
+  def _add_sdk_delayed_applications_to_deferred_inputs(
+      self,
+      bundle_context_manager,  # type: execution.BundleContextManager
+      bundle_result,  # type: beam_fn_api_pb2.InstructionResponse
+      deferred_inputs  # type: MutableMapping[str, execution.PartitionableBuffer]
+  ):
+    # type: (...) -> Set[str]
+
+    """Returns a set of PCollection IDs of PColls having delayed applications.
+
+    This transform inspects the bundle_context_manager, and bundle_result
+    objects, and adds all deferred inputs to the deferred_inputs object.
+    """
+    pcolls_with_delayed_apps = set()
+    for delayed_application in bundle_result.process_bundle.residual_roots:
+      producer_name = bundle_context_manager.input_for(
+          delayed_application.application.transform_id,
+          delayed_application.application.input_id)
+      if producer_name not in deferred_inputs:
+        deferred_inputs[producer_name] = ListBuffer(
+            coder_impl=bundle_context_manager.get_input_coder_impl(
+                producer_name))
+      deferred_inputs[producer_name].append(
+          delayed_application.application.element)
+
+      transform = bundle_context_manager.process_bundle_descriptor.transforms[
+          producer_name]
+      # We take the output with tag 'out' from the producer transform. The
+      # producer transform is a GRPC read, and it has a single output.
+      pcolls_with_delayed_apps.add(only_element(transform.outputs.values()))
+    return pcolls_with_delayed_apps
+
+  def _add_residuals_and_channel_splits_to_deferred_inputs(
+      self,
+      splits,  # type: List[beam_fn_api_pb2.ProcessBundleSplitResponse]
+      bundle_context_manager,  # type: execution.BundleContextManager
+      last_sent,  # type: Dict[str, execution.PartitionableBuffer]
+      deferred_inputs  # type: MutableMapping[str, execution.PartitionableBuffer]
+  ):
+    # type: (...) -> Tuple[Set[str], Set[str]]
+
+    """Returns a two sets representing PCollections with watermark holds.
+
+    The first set represents PCollections with delayed root applications.
+    The second set represents PTransforms with channel splits.
+    """
+
+    pcolls_with_delayed_apps = set()
+    transforms_with_channel_splits = set()
+    prev_stops = {}  # type: Dict[str, int]
+    for split in splits:
+      for delayed_application in split.residual_roots:
+        producer_name = bundle_context_manager.input_for(
+            delayed_application.application.transform_id,
+            delayed_application.application.input_id)
+        if producer_name not in deferred_inputs:
+          deferred_inputs[producer_name] = ListBuffer(
+              coder_impl=bundle_context_manager.get_input_coder_impl(
+                  producer_name))
+        deferred_inputs[producer_name].append(
+            delayed_application.application.element)
+        # We take the output with tag 'out' from the producer transform. The
+        # producer transform is a GRPC read, and it has a single output.
+        pcolls_with_delayed_apps.add(
+            bundle_context_manager.process_bundle_descriptor.
+            transforms[producer_name].outputs['out'])
+      for channel_split in split.channel_splits:
+        coder_impl = bundle_context_manager.get_input_coder_impl(
+            channel_split.transform_id)
+        # Decode and recode to split the encoded buffer by element index.
+        all_elements = list(
+            coder_impl.decode_all(
+                b''.join(last_sent[channel_split.transform_id])))
+        residual_elements = all_elements[
+            channel_split.first_residual_element:prev_stops.
+            get(channel_split.transform_id, len(all_elements)) + 1]
+        if residual_elements:
+          transform = (
+              bundle_context_manager.process_bundle_descriptor.transforms[
+                  channel_split.transform_id])
+          assert transform.spec.urn == bundle_processor.DATA_INPUT_URN
+          transforms_with_channel_splits.add(transform.unique_name)
+
+          if channel_split.transform_id not in deferred_inputs:
+            coder_impl = bundle_context_manager.get_input_coder_impl(
+                channel_split.transform_id)
+            deferred_inputs[channel_split.transform_id] = ListBuffer(
+                coder_impl=coder_impl)
+          deferred_inputs[channel_split.transform_id].append(
+              coder_impl.encode_all(residual_elements))
+        prev_stops[
+            channel_split.transform_id] = channel_split.last_primary_element
+    return pcolls_with_delayed_apps, transforms_with_channel_splits
+
+  def _run_stage(self,
+                 runner_execution_context: RayRunnerExecutionContext,
+                 bundle_context_manager,  # type: execution.BundleContextManager
+                ) -> beam_fn_api_pb2.InstructionResponse:
+
+    """Run an individual stage.
+
+    Args:
+      runner_execution_context: An object containing execution information for
+        the pipeline.
+      bundle_context_manager (execution.BundleContextManager): A description of
+        the stage to execute, and its context.
+    """
+    data_input, data_output, expected_timer_output = (
+        bundle_context_manager.extract_bundle_inputs_and_outputs())
+    runner_execution_context.worker_manager.register_process_bundle_descriptor(
+        bundle_context_manager.process_bundle_descriptor)
+    input_timers = {
+    }  # type: Mapping[translations.TimerFamilyId, execution.PartitionableBuffer]
+
+    _LOGGER.info('Running %s', bundle_context_manager.stage.name)
+
+    final_result = None  # type: Optional[beam_fn_api_pb2.InstructionResponse]
+
+    def merge_results(last_result):
+      # type: (beam_fn_api_pb2.InstructionResponse) -> beam_fn_api_pb2.InstructionResponse
+
+      """ Merge the latest result with other accumulated results. """
+      return (
+          last_result
+          if final_result is None else beam_fn_api_pb2.InstructionResponse(
+              process_bundle=beam_fn_api_pb2.ProcessBundleResponse(
+                  monitoring_infos=monitoring_infos.consolidate(
+                      itertools.chain(
+                          final_result.process_bundle.monitoring_infos,
+                          last_result.process_bundle.monitoring_infos))),
+              error=final_result.error or last_result.error))
+
+    while True:
+      last_result, deferred_inputs, fired_timers, watermark_updates, bundle_outputs = (
+          self._run_bundle(
+              runner_execution_context,
+              bundle_context_manager,
+              data_input,
+              data_output,
+              input_timers,
+              expected_timer_output))
+
+      for pc_name, watermark in watermark_updates.items():
+        runner_execution_context.watermark_manager.set_pcoll_watermark(
+            pc_name, watermark)
+
+      final_result = merge_results(last_result)
+      if not deferred_inputs and not fired_timers:
+        break
+      else:
+        assert (runner_execution_context.watermark_manager.get_stage_node(
+            bundle_context_manager.stage.name).output_watermark()
+                < timestamp.MAX_TIMESTAMP), (
+            'wrong timestamp for %s. '
+            % runner_execution_context.watermark_manager.get_stage_node(
+            bundle_context_manager.stage.name))
+        data_input = deferred_inputs
+        input_timers = fired_timers
+
+    # Store the required downstream side inputs into state so it is accessible
+    # for the worker when it runs bundles that consume this stage's output.
+    data_side_input = (
+        runner_execution_context.side_input_descriptors_by_stage.get(
+            bundle_context_manager.stage.name, {}))
+    runner_execution_context.commit_side_inputs_to_state(data_side_input)
+
+    return final_result
+
+  def _run_bundle(
+      self,
+      runner_execution_context: RayRunnerExecutionContext,
+      bundle_context_manager: execution.BundleContextManager,
+      data_input: Dict[str, execution.PartitionableBuffer],
+      data_output: fn_runner.DataOutput,
+      input_timers: Mapping[translations.TimerFamilyId, execution.PartitionableBuffer],
+      expected_timer_output: Mapping[translations.TimerFamilyId, bytes],
+  ) -> Tuple[beam_fn_api_pb2.InstructionResponse,
+             Dict[str, execution.PartitionableBuffer],
+             Dict[translations.TimerFamilyId, ListBuffer],
+             Dict[Union[str, translations.TimerFamilyId], timestamp.Timestamp],
+             Dict[Union[str, translations.TimerFamilyId], execution.PartitionableBuffer]]:
+    """Execute a bundle, and return a result object, and deferred inputs."""
+
+    cache_token_generator = fn_runner.FnApiRunner.get_cache_token_generator(static=False)
+
+  # TODO(pabloem): Are there two different IDs? the Bundle ID and PBD ID?
+    process_bundle_id = 'bundle_%s' % bundle_context_manager.process_bundle_descriptor.id
+
+    result, output = ray_execute_bundle(
+        runner_execution_context,
+        bundle_context_manager,
+        runner_execution_context.state_servicer,
+        data_input,
+        input_timers,
+        data_output,
+        expected_timer_output,
+        beam_fn_api_pb2.InstructionRequest(
+            instruction_id=process_bundle_id,
+            process_bundle=beam_fn_api_pb2.ProcessBundleRequest(
+                process_bundle_descriptor_id=bundle_context_manager.process_bundle_descriptor.id,
+                cache_tokens=[next(cache_token_generator)]))
+    )
+
+    # TODO(pabloem): Add support for splitting of results.
+
+    # Now we collect all the deferred inputs remaining from bundle execution.
+    # Deferred inputs can be:
+    # - timers
+    # - SDK-initiated deferred applications of root elements
+    # - Runner-initiated deferred applications of root elements
+    deferred_inputs = {}  # type: Dict[str, execution.PartitionableBuffer]
+
+    watermarks_by_transform_and_timer_family, newly_set_timers = (
+        self._collect_written_timers(bundle_context_manager, output))
+
+    sdk_pcolls_with_da = self._add_sdk_delayed_applications_to_deferred_inputs(
+        bundle_context_manager, result, deferred_inputs)
+
+    runner_pcolls_with_da, transforms_with_channel_splits = (
+        self._add_residuals_and_channel_splits_to_deferred_inputs(
+            [], bundle_context_manager, data_input, deferred_inputs))
+
+    watermark_updates = fn_runner.FnApiRunner._build_watermark_updates(
+        runner_execution_context,
+        data_input.keys(),
+        expected_timer_output.keys(),
+        runner_pcolls_with_da.union(sdk_pcolls_with_da),
+        transforms_with_channel_splits,
+        watermarks_by_transform_and_timer_family)
+
+    # After collecting deferred inputs, we 'pad' the structure with empty
+    # buffers for other expected inputs.
+    if deferred_inputs or newly_set_timers:
+      # The worker will be waiting on these inputs as well.
+      for other_input in data_input:
+        if other_input not in deferred_inputs:
+          deferred_inputs[other_input] = ListBuffer(
+              coder_impl=bundle_context_manager.get_input_coder_impl(
+                  other_input))
+
+    return result, deferred_inputs, newly_set_timers, watermark_updates, output
+
+
+class RayMetrics(metric.MetricResults):
+  def __init__(self, step_monitoring_infos, ray_metrics: _RayMetricsActor):
+    """Used for querying metrics from the PipelineResult object.
+
+      step_monitoring_infos: Per step metrics specified as MonitoringInfos.
+      user_metrics_only: If true, includes user metrics only.
+    """
+    self._metrics_actor = ray_metrics
+
+  def query(self, filter=None):
+    counters = [
+        # TODO
+    ]
+    distributions = [# TODO
+    ]
+    gauges = [
+        # TODO
+    ]
+
+    return {
+        self.COUNTERS: counters,
+        self.DISTRIBUTIONS: distributions,
+        self.GAUGES: gauges
+    }
+
+  def monitoring_infos(self):
+    # type: () -> List[metrics_pb2.MonitoringInfo]
+    return [
+        # TODO
+    ]
+
+
+class RayRunnerResult(runner.PipelineResult):
+  def __init__(self, state, ray_metrics: _RayMetricsActor):
+    super().__init__(state)
+    self._metrics = ray_metrics
+
+  def wait_until_finish(self, duration=None):
+    return None
+
+  def metrics(self):
+    """Returns a queryable object including user metrics only."""
+    # TODO(pabloem): Implement this based on _RayMetricsActor
+    raise NotImplementedError()
+
+  def monitoring_metrics(self):
+    """Returns a queryable object including all metrics."""
+    # TODO(pabloem): Implement this based on _RayMetricsActor
+    raise NotImplementedError()

--- a/ray_beam_runner/portability/ray_runner_test.py
+++ b/ray_beam_runner/portability/ray_runner_test.py
@@ -1,0 +1,1939 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# pytype: skip-file
+
+import collections
+import gc
+import logging
+import os
+import random
+import re
+import shutil
+import tempfile
+import threading
+import time
+import traceback
+import typing
+import unittest
+import uuid
+from typing import Any
+from typing import Dict
+from typing import Tuple
+
+import hamcrest  # pylint: disable=ungrouped-imports
+import pytest
+from hamcrest.core.matcher import Matcher
+from hamcrest.core.string_description import StringDescription
+
+import apache_beam as beam
+from apache_beam.coders import coders
+from apache_beam.coders.coders import StrUtf8Coder
+from apache_beam.io import restriction_trackers
+from apache_beam.io.watermark_estimators import ManualWatermarkEstimator
+from apache_beam.metrics import monitoring_infos
+from apache_beam.metrics.execution import MetricKey
+from apache_beam.metrics.metricbase import MetricName
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.options.value_provider import RuntimeValueProvider
+from apache_beam.portability import python_urns
+from apache_beam.runners.portability import fn_api_runner
+from apache_beam.runners.portability.fn_api_runner import fn_runner
+from apache_beam.runners.sdf_utils import RestrictionTrackerView
+from apache_beam.runners.worker import data_plane
+from apache_beam.runners.worker import statesampler
+from apache_beam.testing.synthetic_pipeline import SyntheticSDFAsSource
+from apache_beam.testing.test_stream import TestStream
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+from apache_beam.transforms import environments
+from apache_beam.transforms import userstate
+from apache_beam.transforms import window
+from apache_beam.utils import timestamp
+
+import ray_beam_runner.portability.ray_fn_runner
+
+if statesampler.FAST_SAMPLER:
+  DEFAULT_SAMPLING_PERIOD_MS = statesampler.DEFAULT_SAMPLING_PERIOD_MS
+else:
+  DEFAULT_SAMPLING_PERIOD_MS = 0
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _matcher_or_equal_to(value_or_matcher):
+  """Pass-thru for matchers, and wraps value inputs in an equal_to matcher."""
+  if value_or_matcher is None:
+    return None
+  if isinstance(value_or_matcher, Matcher):
+    return value_or_matcher
+  return hamcrest.equal_to(value_or_matcher)
+
+
+def has_urn_and_labels(mi, urn, labels):
+  """Returns true if it the monitoring_info contains the labels and urn."""
+  def contains_labels(mi, labels):
+    # Check all the labels and their values exist in the monitoring_info
+    return all(item in mi.labels.items() for item in labels.items())
+
+  return contains_labels(mi, labels) and mi.urn == urn
+
+
+class RayFnApiRunnerTest(unittest.TestCase):
+  def create_pipeline(self, is_drain=False):
+    return beam.Pipeline(runner=ray_beam_runner.portability.ray_fn_runner.RayFnApiRunner())
+
+  def test_assert_that(self):
+    with self.assertRaisesRegex(Exception, 'Failed assert'):
+      with self.create_pipeline() as p:
+        assert_that(p | beam.Create(['a', 'b']), equal_to(['a']))
+
+  def test_create(self):
+    with self.create_pipeline() as p:
+      assert_that(p | beam.Create(['a', 'b']), equal_to(['a', 'b']))
+
+  def test_pardo(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create(['a', 'bc'])
+          | beam.Map(lambda e: e * 2)
+          | beam.Map(lambda e: e + 'x'))
+      assert_that(res, equal_to(['aax', 'bcbcx']))
+
+  def test_pardo_side_outputs(self):
+    def tee(elem, *tags):
+      for tag in tags:
+        if tag in elem:
+          yield beam.pvalue.TaggedOutput(tag, elem)
+
+    with self.create_pipeline() as p:
+      xy = (
+          p
+          | 'Create' >> beam.Create(['x', 'y', 'xy'])
+          | beam.FlatMap(tee, 'x', 'y').with_outputs())
+      assert_that(xy.x, equal_to(['x', 'xy']), label='x')
+      assert_that(xy.y, equal_to(['y', 'xy']), label='y')
+
+  def test_pardo_side_and_main_outputs(self):
+    def even_odd(elem):
+      yield elem
+      yield beam.pvalue.TaggedOutput('odd' if elem % 2 else 'even', elem)
+
+    with self.create_pipeline() as p:
+      ints = p | beam.Create([1, 2, 3])
+      named = ints | 'named' >> beam.FlatMap(even_odd).with_outputs(
+          'even', 'odd', main='all')
+      assert_that(named.all, equal_to([1, 2, 3]), label='named.all')
+      assert_that(named.even, equal_to([2]), label='named.even')
+      assert_that(named.odd, equal_to([1, 3]), label='named.odd')
+
+      unnamed = ints | 'unnamed' >> beam.FlatMap(even_odd).with_outputs()
+      unnamed[None] | beam.Map(id)  # pylint: disable=expression-not-assigned
+      assert_that(unnamed[None], equal_to([1, 2, 3]), label='unnamed.all')
+      assert_that(unnamed.even, equal_to([2]), label='unnamed.even')
+      assert_that(unnamed.odd, equal_to([1, 3]), label='unnamed.odd')
+
+  def test_pardo_side_inputs(self):
+    def cross_product(elem, sides):
+      for side in sides:
+        yield elem, side
+
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create(['a', 'b', 'c'])
+      side = p | 'side' >> beam.Create(['x', 'y'])
+      assert_that(
+          main | beam.FlatMap(cross_product, beam.pvalue.AsList(side)),
+          equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'), ('a', 'y'), ('b', 'y'),
+                    ('c', 'y')]))
+
+  def test_pardo_side_input_dependencies(self):
+    with self.create_pipeline() as p:
+      inputs = [p | beam.Create([None])]
+      for k in range(1, 10):
+        inputs.append(
+            inputs[0] | beam.ParDo(
+                ExpectingSideInputsFn(f'Do{k}'),
+                *[beam.pvalue.AsList(inputs[s]) for s in range(1, k)]))
+
+  def test_pardo_side_input_sparse_dependencies(self):
+    with self.create_pipeline() as p:
+      inputs = []
+
+      def choose_input(s):
+        return inputs[(389 + s * 5077) % len(inputs)]
+
+      for k in range(30):
+        num_inputs = int((k * k % 16)**0.5)
+        if num_inputs == 0:
+          inputs.append(p | f'Create{k}' >> beam.Create([f'Create{k}']))
+        else:
+          inputs.append(
+              choose_input(0) | beam.ParDo(
+                  ExpectingSideInputsFn(f'Do{k}'),
+                  *[
+                      beam.pvalue.AsList(choose_input(s))
+                      for s in range(1, num_inputs)
+                  ]))
+
+  def test_pardo_windowed_side_inputs(self):
+    with self.create_pipeline() as p:
+      # Now with some windowing.
+      pcoll = p | beam.Create(list(
+          range(10))) | beam.Map(lambda t: window.TimestampedValue(t, t))
+      # Intentionally choosing non-aligned windows to highlight the transition.
+      main = pcoll | 'WindowMain' >> beam.WindowInto(window.FixedWindows(5))
+      side = pcoll | 'WindowSide' >> beam.WindowInto(window.FixedWindows(7))
+      res = main | beam.Map(
+          lambda x, s: (x, sorted(s)), beam.pvalue.AsList(side))
+      assert_that(
+          res,
+          equal_to([
+              # The window [0, 5) maps to the window [0, 7).
+              (0, list(range(7))),
+              (1, list(range(7))),
+              (2, list(range(7))),
+              (3, list(range(7))),
+              (4, list(range(7))),
+              # The window [5, 10) maps to the window [7, 14).
+              (5, list(range(7, 10))),
+              (6, list(range(7, 10))),
+              (7, list(range(7, 10))),
+              (8, list(range(7, 10))),
+              (9, list(range(7, 10)))
+          ]),
+          label='windowed')
+
+  def test_flattened_side_input(self, with_transcoding=True):
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create([None])
+      side1 = p | 'side1' >> beam.Create([('a', 1)])
+      side2 = p | 'side2' >> beam.Create([('b', 2)])
+      if with_transcoding:
+        # Also test non-matching coder types (transcoding required)
+        third_element = [('another_type')]
+      else:
+        third_element = [('b', 3)]
+      side3 = p | 'side3' >> beam.Create(third_element)
+      side = (side1, side2) | beam.Flatten()
+      assert_that(
+          main | beam.Map(lambda a, b: (a, b), beam.pvalue.AsDict(side)),
+          equal_to([(None, {
+              'a': 1, 'b': 2
+          })]),
+          label='CheckFlattenAsSideInput')
+      assert_that((side, side3) | 'FlattenAfter' >> beam.Flatten(),
+                  equal_to([('a', 1), ('b', 2)] + third_element),
+                  label='CheckFlattenOfSideInput')
+
+  def test_gbk_side_input(self):
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create([None])
+      side = p | 'side' >> beam.Create([('a', 1)]) | beam.GroupByKey()
+      assert_that(
+          main | beam.Map(lambda a, b: (a, b), beam.pvalue.AsDict(side)),
+          equal_to([(None, {
+              'a': [1]
+          })]))
+
+  def test_multimap_side_input(self):
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create(['a', 'b'])
+      side = p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
+      assert_that(
+          main | beam.Map(
+              lambda k, d: (k, sorted(d[k])), beam.pvalue.AsMultiMap(side)),
+          equal_to([('a', [1, 3]), ('b', [2])]))
+
+  def test_multimap_multiside_input(self):
+    # A test where two transforms in the same stage consume the same PCollection
+    # twice as side input.
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create(['a', 'b'])
+      side = p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
+      assert_that(
+          main | 'first map' >> beam.Map(
+              lambda k,
+              d,
+              l: (k, sorted(d[k]), sorted([e[1] for e in l])),
+              beam.pvalue.AsMultiMap(side),
+              beam.pvalue.AsList(side))
+          | 'second map' >> beam.Map(
+              lambda k,
+              d,
+              l: (k[0], sorted(d[k[0]]), sorted([e[1] for e in l])),
+              beam.pvalue.AsMultiMap(side),
+              beam.pvalue.AsList(side)),
+          equal_to([('a', [1, 3], [1, 2, 3]), ('b', [2], [1, 2, 3])]))
+
+  def test_multimap_side_input_type_coercion(self):
+    with self.create_pipeline() as p:
+      main = p | 'main' >> beam.Create(['a', 'b'])
+      # The type of this side-input is forced to Any (overriding type
+      # inference). Without type coercion to Tuple[Any, Any], the usage of this
+      # side-input in AsMultiMap() below should fail.
+      side = (
+          p | 'side' >> beam.Create([('a', 1), ('b', 2),
+                                     ('a', 3)]).with_output_types(typing.Any))
+      assert_that(
+          main | beam.Map(
+              lambda k, d: (k, sorted(d[k])), beam.pvalue.AsMultiMap(side)),
+          equal_to([('a', [1, 3]), ('b', [2])]))
+
+  def test_pardo_unfusable_side_inputs(self):
+    def cross_product(elem, sides):
+      for side in sides:
+        yield elem, side
+
+    with self.create_pipeline() as p:
+      pcoll = p | beam.Create(['a', 'b'])
+      assert_that(
+          pcoll | beam.FlatMap(cross_product, beam.pvalue.AsList(pcoll)),
+          equal_to([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]))
+
+    with self.create_pipeline() as p:
+      pcoll = p | beam.Create(['a', 'b'])
+      derived = ((pcoll, ) | beam.Flatten()
+                 | beam.Map(lambda x: (x, x))
+                 | beam.GroupByKey()
+                 | 'Unkey' >> beam.Map(lambda kv: kv[0]))
+      assert_that(
+          pcoll | beam.FlatMap(cross_product, beam.pvalue.AsList(derived)),
+          equal_to([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]))
+
+  def test_pardo_state_only(self):
+    index_state_spec = userstate.CombiningValueStateSpec('index', sum)
+    value_and_index_state_spec = userstate.ReadModifyWriteStateSpec(
+        'value:index', StrUtf8Coder())
+
+    # TODO(ccy): State isn't detected with Map/FlatMap.
+    class AddIndex(beam.DoFn):
+      def process(
+          self,
+          kv,
+          index=beam.DoFn.StateParam(index_state_spec),
+          value_and_index=beam.DoFn.StateParam(value_and_index_state_spec)):
+        k, v = kv
+        index.add(1)
+        value_and_index.write('%s:%s' % (v, index.read()))
+        yield k, v, index.read(), value_and_index.read()
+
+    inputs = [('A', 'a')] * 2 + [('B', 'b')] * 3
+    expected = [('A', 'a', 1, 'a:1'), ('A', 'a', 2, 'a:2'),
+                ('B', 'b', 1, 'b:1'), ('B', 'b', 2, 'b:2'),
+                ('B', 'b', 3, 'b:3')]
+
+    with self.create_pipeline() as p:
+      assert_that(
+          p | beam.Create(inputs) | beam.ParDo(AddIndex()), equal_to(expected))
+
+  @unittest.skip('TestStream not yet supported')
+  def test_teststream_pardo_timers(self):
+    timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
+
+    class TimerDoFn(beam.DoFn):
+      def process(self, element, timer=beam.DoFn.TimerParam(timer_spec)):
+        unused_key, ts = element
+        timer.set(ts)
+        timer.set(2 * ts)
+
+      @userstate.on_timer(timer_spec)
+      def process_timer(self):
+        yield 'fired'
+
+    ts = (
+        TestStream().add_elements([('k1', 10)])  # Set timer for 20
+        .advance_watermark_to(100).add_elements([('k2', 100)
+                                                 ])  # Set timer for 200
+        .advance_watermark_to(1000))
+
+    with self.create_pipeline() as p:
+      _ = (
+          p
+          | ts
+          | beam.ParDo(TimerDoFn())
+          | beam.Map(lambda x, ts=beam.DoFn.TimestampParam: (x, ts)))
+
+      #expected = [('fired', ts) for ts in (20, 200)]
+      #assert_that(actual, equal_to(expected))
+
+  def test_pardo_timers(self):
+    timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
+    state_spec = userstate.CombiningValueStateSpec('num_called', sum)
+
+    class TimerDoFn(beam.DoFn):
+      def process(self, element, timer=beam.DoFn.TimerParam(timer_spec)):
+        unused_key, ts = element
+        timer.set(ts)
+        timer.set(2 * ts)
+
+      @userstate.on_timer(timer_spec)
+      def process_timer(
+          self,
+          ts=beam.DoFn.TimestampParam,
+          timer=beam.DoFn.TimerParam(timer_spec),
+          state=beam.DoFn.StateParam(state_spec)):
+        if state.read() == 0:
+          state.add(1)
+          timer.set(timestamp.Timestamp(micros=2 * ts.micros))
+        yield 'fired'
+
+    with self.create_pipeline() as p:
+      actual = (
+          p
+          | beam.Create([('k1', 10), ('k2', 100)])
+          | beam.ParDo(TimerDoFn())
+          | beam.Map(lambda x, ts=beam.DoFn.TimestampParam: (x, ts)))
+
+      expected = [('fired', ts) for ts in (20, 200, 40, 400)]
+      assert_that(actual, equal_to(expected))
+
+  def test_pardo_timers_clear(self):
+    timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
+    clear_timer_spec = userstate.TimerSpec(
+        'clear_timer', userstate.TimeDomain.WATERMARK)
+
+    class TimerDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          timer=beam.DoFn.TimerParam(timer_spec),
+          clear_timer=beam.DoFn.TimerParam(clear_timer_spec)):
+        unused_key, ts = element
+        timer.set(ts)
+        timer.set(2 * ts)
+        clear_timer.set(ts)
+        clear_timer.clear()
+
+      @userstate.on_timer(timer_spec)
+      def process_timer(self):
+        yield 'fired'
+
+      @userstate.on_timer(clear_timer_spec)
+      def process_clear_timer(self):
+        yield 'should not fire'
+
+    with self.create_pipeline() as p:
+      actual = (
+          p
+          | beam.Create([('k1', 10), ('k2', 100)])
+          | beam.ParDo(TimerDoFn())
+          | beam.Map(lambda x, ts=beam.DoFn.TimestampParam: (x, ts)))
+
+      expected = [('fired', ts) for ts in (20, 200)]
+      assert_that(actual, equal_to(expected))
+
+  def test_pardo_state_timers(self):
+    self._run_pardo_state_timers(windowed=False)
+
+  def test_pardo_state_timers_non_standard_coder(self):
+    self._run_pardo_state_timers(windowed=False, key_type=Any)
+
+  def test_windowed_pardo_state_timers(self):
+    self._run_pardo_state_timers(windowed=True)
+
+  def _run_pardo_state_timers(self, windowed, key_type=None):
+    """
+    :param windowed: If True, uses an interval window, otherwise a global window
+    :param key_type: Allows to override the inferred key type. This is useful to
+    test the use of non-standard coders, e.g. Python's FastPrimitivesCoder.
+    """
+    state_spec = userstate.BagStateSpec('state', beam.coders.StrUtf8Coder())
+    timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
+    elements = list('abcdefgh')
+    key = 'key'
+    buffer_size = 3
+
+    class BufferDoFn(beam.DoFn):
+      def process(
+          self,
+          kv,
+          ts=beam.DoFn.TimestampParam,
+          timer=beam.DoFn.TimerParam(timer_spec),
+          state=beam.DoFn.StateParam(state_spec)):
+        _, element = kv
+        state.add(element)
+        buffer = state.read()
+        # For real use, we'd keep track of this size separately.
+        if len(list(buffer)) >= 3:
+          state.clear()
+          yield buffer
+        else:
+          timer.set(ts + 1)
+
+      @userstate.on_timer(timer_spec)
+      def process_timer(self, state=beam.DoFn.StateParam(state_spec)):
+        buffer = state.read()
+        state.clear()
+        yield buffer
+
+    def is_buffered_correctly(actual):
+      # Pickling self in the closure for asserts gives errors (only on jenkins).
+      self = FnApiRunnerTest('__init__')
+      # Acutal should be a grouping of the inputs into batches of size
+      # at most buffer_size, but the actual batching is nondeterministic
+      # based on ordering and trigger firing timing.
+      self.assertEqual(sorted(sum((list(b) for b in actual), [])), elements)
+      self.assertEqual(max(len(list(buffer)) for buffer in actual), buffer_size)
+      if windowed:
+        # Elements were assigned to windows based on their parity.
+        # Assert that each grouping consists of elements belonging to the
+        # same window to ensure states and timers were properly partitioned.
+        for b in actual:
+          parity = set(ord(e) % 2 for e in b)
+          self.assertEqual(1, len(parity), b)
+
+    with self.create_pipeline() as p:
+      actual = (
+          p
+          | beam.Create(elements)
+          # Send even and odd elements to different windows.
+          | beam.Map(lambda e: window.TimestampedValue(e, ord(e) % 2))
+          | beam.WindowInto(
+              window.FixedWindows(1) if windowed else window.GlobalWindows())
+          | beam.Map(lambda x: (key, x)).with_output_types(
+              Tuple[key_type if key_type else type(key), Any])
+          | beam.ParDo(BufferDoFn()))
+
+      assert_that(actual, is_buffered_correctly)
+
+  def test_pardo_dynamic_timer(self):
+    class DynamicTimerDoFn(beam.DoFn):
+      dynamic_timer_spec = userstate.TimerSpec(
+          'dynamic_timer', userstate.TimeDomain.WATERMARK)
+
+      def process(
+          self, element,
+          dynamic_timer=beam.DoFn.TimerParam(dynamic_timer_spec)):
+        dynamic_timer.set(element[1], dynamic_timer_tag=element[0])
+
+      @userstate.on_timer(dynamic_timer_spec)
+      def dynamic_timer_callback(
+          self,
+          tag=beam.DoFn.DynamicTimerTagParam,
+          timestamp=beam.DoFn.TimestampParam):
+        yield (tag, timestamp)
+
+    with self.create_pipeline() as p:
+      actual = (
+          p
+          | beam.Create([('key1', 10), ('key2', 20), ('key3', 30)])
+          | beam.ParDo(DynamicTimerDoFn()))
+      assert_that(actual, equal_to([('key1', 10), ('key2', 20), ('key3', 30)]))
+
+  def test_sdf(self):
+    class ExpandingStringsDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              ExpandStringsProvider())):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield element[cur]
+          cur += 1
+
+    with self.create_pipeline() as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
+      assert_that(actual, equal_to(list(''.join(data))))
+
+  def test_sdf_with_dofn_as_restriction_provider(self):
+    class ExpandingStringsDoFn(beam.DoFn, ExpandStringsProvider):
+      def process(
+          self, element, restriction_tracker=beam.DoFn.RestrictionParam()):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield element[cur]
+          cur += 1
+
+    with self.create_pipeline() as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
+      assert_that(actual, equal_to(list(''.join(data))))
+
+  def test_sdf_with_check_done_failed(self):
+    class ExpandingStringsDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              ExpandStringsProvider())):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield element[cur]
+          cur += 1
+          return
+
+    with self.assertRaises(Exception):
+      with self.create_pipeline() as p:
+        data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+        _ = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
+
+  def test_sdf_with_watermark_tracking(self):
+    class ExpandingStringsDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              ExpandStringsProvider()),
+          watermark_estimator=beam.DoFn.WatermarkEstimatorParam(
+              ManualWatermarkEstimator.default_provider())):
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          watermark_estimator.set_watermark(timestamp.Timestamp(cur))
+          assert (
+              watermark_estimator.current_watermark() == timestamp.Timestamp(
+                  cur))
+          yield element[cur]
+          if cur % 2 == 1:
+            restriction_tracker.defer_remainder(timestamp.Duration(micros=5))
+            return
+          cur += 1
+
+    with self.create_pipeline() as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
+      assert_that(actual, equal_to(list(''.join(data))))
+
+  def test_sdf_with_dofn_as_watermark_estimator(self):
+    class ExpandingStringsDoFn(beam.DoFn, beam.WatermarkEstimatorProvider):
+      def initial_estimator_state(self, element, restriction):
+        return None
+
+      def create_watermark_estimator(self, state):
+        return beam.io.watermark_estimators.ManualWatermarkEstimator(state)
+
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              ExpandStringsProvider()),
+          watermark_estimator=beam.DoFn.WatermarkEstimatorParam(
+              ManualWatermarkEstimator.default_provider())):
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          watermark_estimator.set_watermark(timestamp.Timestamp(cur))
+          assert (
+              watermark_estimator.current_watermark() == timestamp.Timestamp(
+                  cur))
+          yield element[cur]
+          if cur % 2 == 1:
+            restriction_tracker.defer_remainder(timestamp.Duration(micros=5))
+            return
+          cur += 1
+
+    with self.create_pipeline() as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
+      assert_that(actual, equal_to(list(''.join(data))))
+
+  def run_sdf_initiated_checkpointing(self, is_drain=False):
+    counter = beam.metrics.Metrics.counter('ns', 'my_counter')
+
+    class ExpandStringsDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              ExpandStringsProvider())):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          counter.inc()
+          yield element[cur]
+          if cur % 2 == 1:
+            restriction_tracker.defer_remainder()
+            return
+          cur += 1
+
+    with self.create_pipeline(is_drain=is_drain) as p:
+      data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
+      actual = (p | beam.Create(data) | beam.ParDo(ExpandStringsDoFn()))
+
+      assert_that(actual, equal_to(list(''.join(data))))
+
+    if isinstance(p.runner, fn_api_runner.FnApiRunner):
+      res = p.runner._latest_run_result
+      counters = res.metrics().query(
+          beam.metrics.MetricsFilter().with_name('my_counter'))['counters']
+      self.assertEqual(1, len(counters))
+      self.assertEqual(counters[0].committed, len(''.join(data)))
+
+  def test_sdf_with_sdf_initiated_checkpointing(self):
+    self.run_sdf_initiated_checkpointing(is_drain=False)
+
+  def test_draining_sdf_with_sdf_initiated_checkpointing(self):
+    self.run_sdf_initiated_checkpointing(is_drain=True)
+
+  def test_sdf_default_truncate_when_bounded(self):
+    class SimleSDF(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              OffsetRangeProvider(use_bounded_offset_range=True))):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield cur
+          cur += 1
+
+    with self.create_pipeline(is_drain=True) as p:
+      actual = (p | beam.Create([10]) | beam.ParDo(SimleSDF()))
+      assert_that(actual, equal_to(range(10)))
+
+  def test_sdf_default_truncate_when_unbounded(self):
+    class SimleSDF(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              OffsetRangeProvider(use_bounded_offset_range=False))):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield cur
+          cur += 1
+
+    with self.create_pipeline(is_drain=True) as p:
+      actual = (p | beam.Create([10]) | beam.ParDo(SimleSDF()))
+      assert_that(actual, equal_to([]))
+
+  def test_sdf_with_truncate(self):
+    class SimleSDF(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              OffsetRangeProviderWithTruncate())):
+        assert isinstance(restriction_tracker, RestrictionTrackerView)
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          yield cur
+          cur += 1
+
+    with self.create_pipeline(is_drain=True) as p:
+      actual = (p | beam.Create([10]) | beam.ParDo(SimleSDF()))
+      assert_that(actual, equal_to(range(5)))
+
+  def test_group_by_key(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create([('a', 1), ('a', 2), ('b', 3)])
+          | beam.GroupByKey()
+          | beam.Map(lambda k_vs: (k_vs[0], sorted(k_vs[1]))))
+      assert_that(res, equal_to([('a', [1, 2]), ('b', [3])]))
+
+  # Runners may special case the Reshuffle transform urn.
+  def test_reshuffle(self):
+    with self.create_pipeline() as p:
+      assert_that(
+          p | beam.Create([1, 2, 3]) | beam.Reshuffle(), equal_to([1, 2, 3]))
+
+  def test_flatten(self, with_transcoding=True):
+    with self.create_pipeline() as p:
+      if with_transcoding:
+        # Additional element which does not match with the first type
+        additional = [ord('d')]
+      else:
+        additional = ['d']
+      res = (
+          p | 'a' >> beam.Create(['a']),
+          p | 'bc' >> beam.Create(['b', 'c']),
+          p | 'd' >> beam.Create(additional)) | beam.Flatten()
+      assert_that(res, equal_to(['a', 'b', 'c'] + additional))
+
+  def test_flatten_same_pcollections(self, with_transcoding=True):
+    with self.create_pipeline() as p:
+      pc = p | beam.Create(['a', 'b'])
+      assert_that((pc, pc, pc) | beam.Flatten(), equal_to(['a', 'b'] * 3))
+
+  def test_combine_per_key(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create([('a', 1), ('a', 2), ('b', 3)])
+          | beam.CombinePerKey(beam.combiners.MeanCombineFn()))
+      assert_that(res, equal_to([('a', 1.5), ('b', 3.0)]))
+
+  def test_read(self):
+    # Can't use NamedTemporaryFile as a context
+    # due to https://bugs.python.org/issue14243
+    temp_file = tempfile.NamedTemporaryFile(delete=False)
+    try:
+      temp_file.write(b'a\nb\nc')
+      temp_file.close()
+      with self.create_pipeline() as p:
+        assert_that(
+            p | beam.io.ReadFromText(temp_file.name), equal_to(['a', 'b', 'c']))
+    finally:
+      os.unlink(temp_file.name)
+
+  def test_windowing(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create([1, 2, 100, 101, 102])
+          | beam.Map(lambda t: window.TimestampedValue(('k', t), t))
+          | beam.WindowInto(beam.transforms.window.Sessions(10))
+          | beam.GroupByKey()
+          | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
+      assert_that(res, equal_to([('k', [1, 2]), ('k', [100, 101, 102])]))
+
+  def test_custom_merging_window(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create([1, 2, 100, 101, 102])
+          | beam.Map(lambda t: window.TimestampedValue(('k', t), t))
+          | beam.WindowInto(CustomMergingWindowFn())
+          | beam.GroupByKey()
+          | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
+      assert_that(
+          res, equal_to([('k', [1]), ('k', [101]), ('k', [2, 100, 102])]))
+    gc.collect()
+    from apache_beam.runners.portability.fn_api_runner.execution import GenericMergingWindowFn
+    self.assertEqual(GenericMergingWindowFn._HANDLES, {})
+
+  @unittest.skip('BEAM-9119: test is flaky')
+  def test_large_elements(self):
+    with self.create_pipeline() as p:
+      big = (
+          p
+          | beam.Create(['a', 'a', 'b'])
+          |
+          beam.Map(lambda x: (x, x * data_plane._DEFAULT_SIZE_FLUSH_THRESHOLD)))
+
+      side_input_res = (
+          big
+          | beam.Map(
+              lambda x,
+              side: (x[0], side.count(x[0])),
+              beam.pvalue.AsList(big | beam.Map(lambda x: x[0]))))
+      assert_that(
+          side_input_res,
+          equal_to([('a', 2), ('a', 2), ('b', 1)]),
+          label='side')
+
+      gbk_res = (big | beam.GroupByKey() | beam.Map(lambda x: x[0]))
+      assert_that(gbk_res, equal_to(['a', 'b']), label='gbk')
+
+  def test_error_message_includes_stage(self):
+    with self.assertRaises(BaseException) as e_cm:
+      with self.create_pipeline() as p:
+
+        def raise_error(x):
+          raise RuntimeError('x')
+
+        # pylint: disable=expression-not-assigned
+        (
+            p
+            | beam.Create(['a', 'b'])
+            | 'StageA' >> beam.Map(lambda x: x)
+            | 'StageB' >> beam.Map(lambda x: x)
+            | 'StageC' >> beam.Map(raise_error)
+            | 'StageD' >> beam.Map(lambda x: x))
+    message = e_cm.exception.args[0]
+    self.assertIn('StageC', message)
+    self.assertNotIn('StageB', message)
+
+  def test_error_traceback_includes_user_code(self):
+    def first(x):
+      return second(x)
+
+    def second(x):
+      return third(x)
+
+    def third(x):
+      raise ValueError('x')
+
+    try:
+      with self.create_pipeline() as p:
+        p | beam.Create([0]) | beam.Map(first)  # pylint: disable=expression-not-assigned
+    except Exception:  # pylint: disable=broad-except
+      message = traceback.format_exc()
+    else:
+      raise AssertionError('expected exception not raised')
+
+    self.assertIn('first', message)
+    self.assertIn('second', message)
+    self.assertIn('third', message)
+
+  def test_no_subtransform_composite(self):
+    class First(beam.PTransform):
+      def expand(self, pcolls):
+        return pcolls[0]
+
+    with self.create_pipeline() as p:
+      pcoll_a = p | 'a' >> beam.Create(['a'])
+      pcoll_b = p | 'b' >> beam.Create(['b'])
+      assert_that((pcoll_a, pcoll_b) | First(), equal_to(['a']))
+
+  def test_metrics(self, check_gauge=True):
+    p = self.create_pipeline()
+
+    counter = beam.metrics.Metrics.counter('ns', 'counter')
+    distribution = beam.metrics.Metrics.distribution('ns', 'distribution')
+    gauge = beam.metrics.Metrics.gauge('ns', 'gauge')
+
+    pcoll = p | beam.Create(['a', 'zzz'])
+    # pylint: disable=expression-not-assigned
+    pcoll | 'count1' >> beam.FlatMap(lambda x: counter.inc())
+    pcoll | 'count2' >> beam.FlatMap(lambda x: counter.inc(len(x)))
+    pcoll | 'dist' >> beam.FlatMap(lambda x: distribution.update(len(x)))
+    pcoll | 'gauge' >> beam.FlatMap(lambda x: gauge.set(3))
+
+    res = p.run()
+    res.wait_until_finish()
+
+    t1, t2 = res.metrics().query(beam.metrics.MetricsFilter()
+                                 .with_name('counter'))['counters']
+    self.assertEqual(t1.committed + t2.committed, 6)
+
+    dist, = res.metrics().query(beam.metrics.MetricsFilter()
+                                .with_name('distribution'))['distributions']
+    self.assertEqual(
+        dist.committed.data, beam.metrics.cells.DistributionData(4, 2, 1, 3))
+    self.assertEqual(dist.committed.mean, 2.0)
+
+    if check_gauge:
+      gaug, = res.metrics().query(beam.metrics.MetricsFilter()
+                                  .with_name('gauge'))['gauges']
+      self.assertEqual(gaug.committed.value, 3)
+
+  def test_callbacks_with_exception(self):
+    elements_list = ['1', '2']
+
+    def raise_expetion():
+      raise Exception('raise exception when calling callback')
+
+    class FinalizebleDoFnWithException(beam.DoFn):
+      def process(
+          self, element, bundle_finalizer=beam.DoFn.BundleFinalizerParam):
+        bundle_finalizer.register(raise_expetion)
+        yield element
+
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create(elements_list)
+          | beam.ParDo(FinalizebleDoFnWithException()))
+      assert_that(res, equal_to(['1', '2']))
+
+  def test_register_finalizations(self):
+    event_recorder = EventRecorder(tempfile.gettempdir())
+
+    class FinalizableSplittableDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          bundle_finalizer=beam.DoFn.BundleFinalizerParam,
+          restriction_tracker=beam.DoFn.RestrictionParam(
+              OffsetRangeProvider(
+                  use_bounded_offset_range=True, checkpoint_only=True))):
+        # We use SDF to enforce finalization call happens by using
+        # self-initiated checkpoint.
+        if 'finalized' in event_recorder.events():
+          restriction_tracker.try_claim(
+              restriction_tracker.current_restriction().start)
+          yield element
+          restriction_tracker.try_claim(element)
+          return
+        if restriction_tracker.try_claim(
+            restriction_tracker.current_restriction().start):
+          bundle_finalizer.register(lambda: event_recorder.record('finalized'))
+          # We sleep here instead of setting a resume time since the resume time
+          # doesn't need to be honored.
+          time.sleep(1)
+          restriction_tracker.defer_remainder()
+
+    with self.create_pipeline() as p:
+      max_retries = 100
+      res = (
+          p
+          | beam.Create([max_retries])
+          | beam.ParDo(FinalizableSplittableDoFn()))
+      assert_that(res, equal_to([max_retries]))
+
+    event_recorder.cleanup()
+
+  def test_sdf_synthetic_source(self):
+    common_attrs = {
+        'key_size': 1,
+        'value_size': 1,
+        'initial_splitting_num_bundles': 2,
+        'initial_splitting_desired_bundle_size': 2,
+        'sleep_per_input_record_sec': 0,
+        'initial_splitting': 'const'
+    }
+    num_source_description = 5
+    min_num_record = 10
+    max_num_record = 20
+
+    # pylint: disable=unused-variable
+    source_descriptions = ([
+        dict({'num_records': random.randint(min_num_record, max_num_record)},
+             **common_attrs) for i in range(0, num_source_description)
+    ])
+    total_num_records = 0
+    for source in source_descriptions:
+      total_num_records += source['num_records']
+
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create(source_descriptions)
+          | beam.ParDo(SyntheticSDFAsSource())
+          | beam.combiners.Count.Globally())
+      assert_that(res, equal_to([total_num_records]))
+
+  def test_create_value_provider_pipeline_option(self):
+    # Verify that the runner can execute a pipeline when there are value
+    # provider pipeline options
+    # pylint: disable=unused-variable
+    class FooOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_value_provider_argument(
+            "--foo", help='a value provider argument', default="bar")
+
+    RuntimeValueProvider.set_runtime_options({})
+
+    with self.create_pipeline() as p:
+      assert_that(p | beam.Create(['a', 'b']), equal_to(['a', 'b']))
+
+  def _test_pack_combiners(self, assert_using_counter_names):
+    counter = beam.metrics.Metrics.counter('ns', 'num_values')
+
+    def min_with_counter(values):
+      counter.inc()
+      return min(values)
+
+    def max_with_counter(values):
+      counter.inc()
+      return max(values)
+
+    class PackableCombines(beam.PTransform):
+      def annotations(self):
+        return {python_urns.APPLY_COMBINER_PACKING: b''}
+
+      def expand(self, pcoll):
+        assert_that(
+            pcoll | 'PackableMin' >> beam.CombineGlobally(min_with_counter),
+            equal_to([10]),
+            label='AssertMin')
+        assert_that(
+            pcoll | 'PackableMax' >> beam.CombineGlobally(max_with_counter),
+            equal_to([30]),
+            label='AssertMax')
+
+    with self.create_pipeline() as p:
+      _ = p | beam.Create([10, 20, 30]) | PackableCombines()
+
+    res = p.run()
+    res.wait_until_finish()
+
+    packed_step_name_regex = (
+        r'.*Packed.*PackableMin.*CombinePerKey.*PackableMax.*CombinePerKey.*' +
+        'Pack.*')
+
+    counters = res.metrics().query(beam.metrics.MetricsFilter())['counters']
+    step_names = set(m.key.step for m in counters if m.key.step)
+    pipeline_options = p._options
+    if assert_using_counter_names:
+      if pipeline_options.view_as(StandardOptions).streaming:
+        self.assertFalse(
+            any(re.match(packed_step_name_regex, s) for s in step_names))
+      else:
+        self.assertTrue(
+            any(re.match(packed_step_name_regex, s) for s in step_names))
+
+  def test_pack_combiners(self):
+    self._test_pack_combiners(assert_using_counter_names=True)
+
+
+# These tests are kept in a separate group so that they are
+# not ran in the FnApiRunnerTestWithBundleRepeat which repeats
+# bundle processing. This breaks the byte sampling metrics as
+# it makes the probability of sampling far too small
+# upon repeating bundle processing due to unncessarily incrementing
+# the sampling counter.
+class FnApiRunnerMetricsTest(unittest.TestCase):
+  def assert_has_counter(
+      self, mon_infos, urn, labels, value=None, ge_value=None):
+    # TODO(ajamato): Consider adding a matcher framework
+    found = 0
+    matches = []
+    for mi in mon_infos:
+      if has_urn_and_labels(mi, urn, labels):
+        extracted_value = monitoring_infos.extract_counter_value(mi)
+        if ge_value is not None:
+          if extracted_value >= ge_value:
+            found = found + 1
+        elif value is not None:
+          if extracted_value == value:
+            found = found + 1
+        else:
+          found = found + 1
+    ge_value_str = {'ge_value': ge_value} if ge_value else ''
+    value_str = {'value': value} if value else ''
+    self.assertEqual(
+        1,
+        found,
+        "Found (%s, %s) Expected only 1 monitoring_info for %s." % (
+            found,
+            matches,
+            (urn, labels, value_str, ge_value_str),
+        ))
+
+  def assert_has_distribution(
+      self, mon_infos, urn, labels, sum=None, count=None, min=None, max=None):
+    # TODO(ajamato): Consider adding a matcher framework
+    sum = _matcher_or_equal_to(sum)
+    count = _matcher_or_equal_to(count)
+    min = _matcher_or_equal_to(min)
+    max = _matcher_or_equal_to(max)
+    found = 0
+    description = StringDescription()
+    for mi in mon_infos:
+      if has_urn_and_labels(mi, urn, labels):
+        (extracted_count, extracted_sum, extracted_min,
+         extracted_max) = monitoring_infos.extract_distribution(mi)
+        increment = 1
+        if sum is not None:
+          description.append_text(' sum: ')
+          sum.describe_to(description)
+          if not sum.matches(extracted_sum):
+            increment = 0
+        if count is not None:
+          description.append_text(' count: ')
+          count.describe_to(description)
+          if not count.matches(extracted_count):
+            increment = 0
+        if min is not None:
+          description.append_text(' min: ')
+          min.describe_to(description)
+          if not min.matches(extracted_min):
+            increment = 0
+        if max is not None:
+          description.append_text(' max: ')
+          max.describe_to(description)
+          if not max.matches(extracted_max):
+            increment = 0
+        found += increment
+    self.assertEqual(
+        1,
+        found,
+        "Found (%s) Expected only 1 monitoring_info for %s." % (
+            found,
+            (urn, labels, str(description)),
+        ))
+
+  def create_pipeline(self):
+    return beam.Pipeline(runner=fn_api_runner.FnApiRunner())
+
+  def test_element_count_metrics(self):
+    class GenerateTwoOutputs(beam.DoFn):
+      def process(self, element):
+        yield str(element) + '1'
+        yield beam.pvalue.TaggedOutput('SecondOutput', str(element) + '2')
+        yield beam.pvalue.TaggedOutput('SecondOutput', str(element) + '2')
+        yield beam.pvalue.TaggedOutput('ThirdOutput', str(element) + '3')
+
+    class PassThrough(beam.DoFn):
+      def process(self, element):
+        yield element
+
+    p = self.create_pipeline()
+
+    # Produce enough elements to make sure byte sampling occurs.
+    num_source_elems = 100
+    pcoll = p | beam.Create(['a%d' % i for i in range(num_source_elems)],
+                            reshuffle=False)
+
+    # pylint: disable=expression-not-assigned
+    pardo = (
+        'StepThatDoesTwoOutputs' >> beam.ParDo(
+            GenerateTwoOutputs()).with_outputs(
+                'SecondOutput', 'ThirdOutput', main='FirstAndMainOutput'))
+
+    # Actually feed pcollection to pardo
+    second_output, third_output, first_output = (pcoll | pardo)
+
+    # consume some of elements
+    merged = ((first_output, second_output, third_output) | beam.Flatten())
+    merged | ('PassThrough') >> beam.ParDo(PassThrough())
+    second_output | ('PassThrough2') >> beam.ParDo(PassThrough())
+
+    res = p.run()
+    res.wait_until_finish()
+
+    result_metrics = res.monitoring_metrics()
+
+    counters = result_metrics.monitoring_infos()
+    # All element count and byte count metrics must have a PCOLLECTION_LABEL.
+    self.assertFalse([
+        x for x in counters if x.urn in [
+            monitoring_infos.ELEMENT_COUNT_URN,
+            monitoring_infos.SAMPLED_BYTE_SIZE_URN
+        ] and monitoring_infos.PCOLLECTION_LABEL not in x.labels
+    ])
+    try:
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_1'
+      }
+      self.assert_has_counter(
+          counters, monitoring_infos.ELEMENT_COUNT_URN, labels, 1)
+
+      # Create output.
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_3'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # GenerateTwoOutputs, main output.
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_4'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # GenerateTwoOutputs, "SecondOutput" output.
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_5'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          2 * num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # GenerateTwoOutputs, "ThirdOutput" output.
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_6'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # Skipping other pcollections due to non-deterministic naming for multiple
+      # outputs.
+      # Flatten/Read, main output.
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_7'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          4 * num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # PassThrough, main output
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_8'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          4 * num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+
+      # PassThrough2, main output
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_9'
+      }
+      self.assert_has_counter(
+          counters,
+          monitoring_infos.ELEMENT_COUNT_URN,
+          labels,
+          num_source_elems)
+      self.assert_has_distribution(
+          counters,
+          monitoring_infos.SAMPLED_BYTE_SIZE_URN,
+          labels,
+          min=hamcrest.greater_than(0),
+          max=hamcrest.greater_than(0),
+          sum=hamcrest.greater_than(0),
+          count=hamcrest.greater_than(0))
+    except:
+      print(res._monitoring_infos_by_stage)
+      raise
+
+  def test_non_user_metrics(self):
+    p = self.create_pipeline()
+
+    pcoll = p | beam.Create(['a', 'zzz'])
+    # pylint: disable=expression-not-assigned
+    pcoll | 'MyStep' >> beam.FlatMap(lambda x: None)
+    res = p.run()
+    res.wait_until_finish()
+
+    result_metrics = res.monitoring_metrics()
+    all_metrics_via_montoring_infos = result_metrics.query()
+
+    def assert_counter_exists(metrics, namespace, name, step):
+      found = 0
+      metric_key = MetricKey(step, MetricName(namespace, name))
+      for m in metrics['counters']:
+        if m.key == metric_key:
+          found = found + 1
+      self.assertEqual(
+          1, found, "Did not find exactly 1 metric for %s." % metric_key)
+
+    urns = [
+        monitoring_infos.START_BUNDLE_MSECS_URN,
+        monitoring_infos.PROCESS_BUNDLE_MSECS_URN,
+        monitoring_infos.FINISH_BUNDLE_MSECS_URN,
+        monitoring_infos.TOTAL_MSECS_URN,
+    ]
+    for urn in urns:
+      split = urn.split(':')
+      namespace = split[0]
+      name = ':'.join(split[1:])
+      assert_counter_exists(
+          all_metrics_via_montoring_infos,
+          namespace,
+          name,
+          step='Create/Impulse')
+      assert_counter_exists(
+          all_metrics_via_montoring_infos, namespace, name, step='MyStep')
+
+  # Due to somewhat non-deterministic nature of state sampling and sleep,
+  # this test is flaky when state duration is low.
+  # Since increasing state duration significantly would also slow down
+  # the test suite, we are retrying twice on failure as a mitigation.
+  def test_progress_metrics(self):
+    p = self.create_pipeline()
+
+    _ = (
+        p
+        | beam.Create([0, 0, 0, 5e-3 * DEFAULT_SAMPLING_PERIOD_MS],
+                      reshuffle=False)
+        | beam.Map(time.sleep)
+        | beam.Map(lambda x: ('key', x))
+        | beam.GroupByKey()
+        | 'm_out' >> beam.FlatMap(
+            lambda x: [
+                1,
+                2,
+                3,
+                4,
+                5,
+                beam.pvalue.TaggedOutput('once', x),
+                beam.pvalue.TaggedOutput('twice', x),
+                beam.pvalue.TaggedOutput('twice', x)
+            ]))
+
+    res = p.run()
+    res.wait_until_finish()
+
+    def has_mi_for_ptransform(mon_infos, ptransform):
+      for mi in mon_infos:
+        if ptransform in mi.labels[monitoring_infos.PTRANSFORM_LABEL]:
+          return True
+      return False
+
+    try:
+      # Test the new MonitoringInfo monitoring format.
+      self.assertEqual(3, len(res._monitoring_infos_by_stage))
+      pregbk_mis, postgbk_mis = [
+          mi for stage, mi in res._monitoring_infos_by_stage.items() if stage]
+
+      if not has_mi_for_ptransform(pregbk_mis, 'Create/Map(decode)'):
+        # The monitoring infos above are actually unordered. Swap.
+        pregbk_mis, postgbk_mis = postgbk_mis, pregbk_mis
+
+      # pregbk monitoring infos
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_3'
+      }
+      self.assert_has_counter(
+          pregbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=4)
+      self.assert_has_distribution(
+          pregbk_mis, monitoring_infos.SAMPLED_BYTE_SIZE_URN, labels)
+
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_4'
+      }
+      self.assert_has_counter(
+          pregbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=4)
+      self.assert_has_distribution(
+          pregbk_mis, monitoring_infos.SAMPLED_BYTE_SIZE_URN, labels)
+
+      labels = {monitoring_infos.PTRANSFORM_LABEL: 'Map(sleep)'}
+      self.assert_has_counter(
+          pregbk_mis,
+          monitoring_infos.TOTAL_MSECS_URN,
+          labels,
+          ge_value=4 * DEFAULT_SAMPLING_PERIOD_MS)
+
+      # postgbk monitoring infos
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_6'
+      }
+      self.assert_has_counter(
+          postgbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=1)
+      self.assert_has_distribution(
+          postgbk_mis, monitoring_infos.SAMPLED_BYTE_SIZE_URN, labels)
+
+      labels = {
+          monitoring_infos.PCOLLECTION_LABEL: 'ref_PCollection_PCollection_7'
+      }
+      self.assert_has_counter(
+          postgbk_mis, monitoring_infos.ELEMENT_COUNT_URN, labels, value=5)
+      self.assert_has_distribution(
+          postgbk_mis, monitoring_infos.SAMPLED_BYTE_SIZE_URN, labels)
+    except:
+      print(res._monitoring_infos_by_stage)
+      raise
+
+
+class FnApiRunnerSplitTest(unittest.TestCase):
+  def create_pipeline(self, is_drain=False):
+    # Must be GRPC so we can send data and split requests concurrent
+    # to the bundle process request.
+    return beam.Pipeline(
+        runner=fn_api_runner.FnApiRunner(
+            default_environment=environments.EmbeddedPythonGrpcEnvironment.
+            default(),
+            is_drain=is_drain))
+
+  def test_checkpoint(self):
+    # This split manager will get re-invoked on each smaller split,
+    # so N times for N elements.
+    element_counter = ElementCounter()
+
+    def split_manager(num_elements):
+      # Send at least one element so it can make forward progress.
+      element_counter.reset()
+      breakpoint = element_counter.set_breakpoint(1)
+      # Cede control back to the runner so data can be sent.
+      yield
+      breakpoint.wait()
+      # Split as close to current as possible.
+      split_result = yield 0.0
+      # Verify we split at exactly the first element.
+      self.verify_channel_split(split_result, 0, 1)
+      # Continue processing.
+      breakpoint.clear()
+
+    self.run_split_pipeline(split_manager, list('abc'), element_counter)
+
+  def test_split_half(self):
+    total_num_elements = 25
+    seen_bundle_sizes = []
+    element_counter = ElementCounter()
+
+    def split_manager(num_elements):
+      seen_bundle_sizes.append(num_elements)
+      if num_elements == total_num_elements:
+        element_counter.reset()
+        breakpoint = element_counter.set_breakpoint(5)
+        yield
+        breakpoint.wait()
+        # Split the remainder (20, then 10, elements) in half.
+        split1 = yield 0.5
+        self.verify_channel_split(split1, 14, 15)  # remainder is 15 to end
+        split2 = yield 0.5
+        self.verify_channel_split(split2, 9, 10)  # remainder is 10 to end
+        breakpoint.clear()
+
+    self.run_split_pipeline(
+        split_manager, range(total_num_elements), element_counter)
+    self.assertEqual([25, 15], seen_bundle_sizes)
+
+  def run_split_pipeline(self, split_manager, elements, element_counter=None):
+    with fn_runner.split_manager('Identity', split_manager):
+      with self.create_pipeline() as p:
+        res = (
+            p
+            | beam.Create(elements)
+            | beam.Reshuffle()
+            | 'Identity' >> beam.Map(lambda x: x)
+            | beam.Map(lambda x: element_counter.increment() or x))
+        assert_that(res, equal_to(elements))
+
+  def run_sdf_checkpoint(self, is_drain=False):
+    element_counter = ElementCounter()
+
+    def split_manager(num_elements):
+      if num_elements > 0:
+        element_counter.reset()
+        breakpoint = element_counter.set_breakpoint(1)
+        yield
+        breakpoint.wait()
+        yield 0
+        breakpoint.clear()
+
+    # Everything should be perfectly split.
+
+    elements = [2, 3]
+    expected_groups = [[(2, 0)], [(2, 1)], [(3, 0)], [(3, 1)], [(3, 2)]]
+    self.run_sdf_split_pipeline(
+        split_manager,
+        elements,
+        element_counter,
+        expected_groups,
+        is_drain=is_drain)
+
+  def run_sdf_split_half(self, is_drain=False):
+    element_counter = ElementCounter()
+    is_first_bundle = True
+
+    def split_manager(num_elements):
+      nonlocal is_first_bundle
+      if is_first_bundle and num_elements > 0:
+        is_first_bundle = False
+        breakpoint = element_counter.set_breakpoint(1)
+        yield
+        breakpoint.wait()
+        split1 = yield 0.5
+        split2 = yield 0.5
+        split3 = yield 0.5
+        self.verify_channel_split(split1, 0, 1)
+        self.verify_channel_split(split2, -1, 1)
+        self.verify_channel_split(split3, -1, 1)
+        breakpoint.clear()
+
+    elements = [4, 4]
+    expected_groups = [[(4, 0)], [(4, 1)], [(4, 2), (4, 3)], [(4, 0), (4, 1),
+                                                              (4, 2), (4, 3)]]
+
+    self.run_sdf_split_pipeline(
+        split_manager,
+        elements,
+        element_counter,
+        expected_groups,
+        is_drain=is_drain)
+
+  def run_split_crazy_sdf(self, seed=None, is_drain=False):
+    if seed is None:
+      seed = random.randrange(1 << 20)
+    r = random.Random(seed)
+    element_counter = ElementCounter()
+
+    def split_manager(num_elements):
+      if num_elements > 0:
+        element_counter.reset()
+        wait_for = r.randrange(num_elements)
+        breakpoint = element_counter.set_breakpoint(wait_for)
+        yield
+        breakpoint.wait()
+        yield r.random()
+        yield r.random()
+        breakpoint.clear()
+
+    try:
+      elements = [r.randrange(5, 10) for _ in range(5)]
+      self.run_sdf_split_pipeline(
+          split_manager, elements, element_counter, is_drain=is_drain)
+    except Exception:
+      _LOGGER.error('test_split_crazy_sdf.seed = %s', seed)
+      raise
+
+  def test_nosplit_sdf(self):
+    def split_manager(num_elements):
+      yield
+
+    elements = [1, 2, 3]
+    expected_groups = [[(e, k) for k in range(e)] for e in elements]
+    self.run_sdf_split_pipeline(
+        split_manager, elements, ElementCounter(), expected_groups)
+
+  def test_checkpoint_sdf(self):
+    self.run_sdf_checkpoint(is_drain=False)
+
+  def test_checkpoint_draining_sdf(self):
+    self.run_sdf_checkpoint(is_drain=True)
+
+  def test_split_half_sdf(self):
+    self.run_sdf_split_half(is_drain=False)
+
+  def test_split_half_draining_sdf(self):
+    self.run_sdf_split_half(is_drain=True)
+
+  def test_split_crazy_sdf(self, seed=None):
+    self.run_split_crazy_sdf(seed=seed, is_drain=False)
+
+  def test_split_crazy_draining_sdf(self, seed=None):
+    self.run_split_crazy_sdf(seed=seed, is_drain=True)
+
+  def run_sdf_split_pipeline(
+      self,
+      split_manager,
+      elements,
+      element_counter,
+      expected_groups=None,
+      is_drain=False):
+    # Define an SDF that for each input x produces [(x, k) for k in range(x)].
+
+    class EnumerateProvider(beam.transforms.core.RestrictionProvider):
+      def initial_restriction(self, element):
+        return restriction_trackers.OffsetRange(0, element)
+
+      def create_tracker(self, restriction):
+        return restriction_trackers.OffsetRestrictionTracker(restriction)
+
+      def split(self, element, restriction):
+        # Don't do any initial splitting to simplify test.
+        return [restriction]
+
+      def restriction_size(self, element, restriction):
+        return restriction.size()
+
+      def is_bounded(self):
+        return True
+
+    class EnumerateSdf(beam.DoFn):
+      def process(
+          self,
+          element,
+          restriction_tracker=beam.DoFn.RestrictionParam(EnumerateProvider())):
+        to_emit = []
+        cur = restriction_tracker.current_restriction().start
+        while restriction_tracker.try_claim(cur):
+          to_emit.append((element, cur))
+          element_counter.increment()
+          cur += 1
+        # Emitting in batches for tighter testing.
+        yield to_emit
+
+    expected = [(e, k) for e in elements for k in range(e)]
+
+    with fn_runner.split_manager('SDF', split_manager):
+      with self.create_pipeline(is_drain=is_drain) as p:
+        grouped = (
+            p
+            | beam.Create(elements, reshuffle=False)
+            | 'SDF' >> beam.ParDo(EnumerateSdf()))
+        flat = grouped | beam.FlatMap(lambda x: x)
+        assert_that(flat, equal_to(expected))
+        if expected_groups:
+          assert_that(grouped, equal_to(expected_groups), label='CheckGrouped')
+
+  def verify_channel_split(self, split_result, last_primary, first_residual):
+    self.assertEqual(1, len(split_result.channel_splits), split_result)
+    channel_split, = split_result.channel_splits
+    self.assertEqual(last_primary, channel_split.last_primary_element)
+    self.assertEqual(first_residual, channel_split.first_residual_element)
+    # There should be a primary and residual application for each element
+    # not covered above.
+    self.assertEqual(
+        first_residual - last_primary - 1,
+        len(split_result.primary_roots),
+        split_result.primary_roots)
+    self.assertEqual(
+        first_residual - last_primary - 1,
+        len(split_result.residual_roots),
+        split_result.residual_roots)
+
+
+class ElementCounter(object):
+  """Used to wait until a certain number of elements are seen."""
+  def __init__(self):
+    self._cv = threading.Condition()
+    self.reset()
+
+  def reset(self):
+    with self._cv:
+      self._breakpoints = collections.defaultdict(list)
+      self._count = 0
+
+  def increment(self):
+    with self._cv:
+      self._count += 1
+      self._cv.notify_all()
+      breakpoints = list(self._breakpoints[self._count])
+    for breakpoint in breakpoints:
+      breakpoint.wait()
+
+  def set_breakpoint(self, value):
+    with self._cv:
+      event = threading.Event()
+      self._breakpoints[value].append(event)
+
+    class Breakpoint(object):
+      @staticmethod
+      def wait(timeout=10):
+        with self._cv:
+          start = time.time()
+          while self._count < value:
+            elapsed = time.time() - start
+            if elapsed > timeout:
+              raise RuntimeError('Timed out waiting for %s' % value)
+            self._cv.wait(timeout - elapsed)
+
+      @staticmethod
+      def clear():
+        event.set()
+
+    return Breakpoint()
+
+  def __reduce__(self):
+    # Ensure we get the same element back through a pickling round-trip.
+    name = uuid.uuid4().hex
+    _pickled_element_counters[name] = self
+    return _unpickle_element_counter, (name, )
+
+
+_pickled_element_counters = {}  # type: Dict[str, ElementCounter]
+
+
+def _unpickle_element_counter(name):
+  return _pickled_element_counters[name]
+
+
+class EventRecorder(object):
+  """Used to be registered as a callback in bundle finalization.
+
+  The reason why records are written into a tmp file is, the in-memory dataset
+  cannot keep callback records when passing into one DoFn.
+  """
+  def __init__(self, tmp_dir):
+    self.tmp_dir = os.path.join(tmp_dir, uuid.uuid4().hex)
+    os.mkdir(self.tmp_dir)
+
+  def record(self, content):
+    file_path = os.path.join(self.tmp_dir, uuid.uuid4().hex + '.txt')
+    with open(file_path, 'w') as f:
+      f.write(content)
+
+  def events(self):
+    content = []
+    record_files = [
+        f for f in os.listdir(self.tmp_dir)
+        if os.path.isfile(os.path.join(self.tmp_dir, f))
+    ]
+    for file in record_files:
+      with open(os.path.join(self.tmp_dir, file), 'r') as f:
+        content.append(f.read())
+    return sorted(content)
+
+  def cleanup(self):
+    shutil.rmtree(self.tmp_dir)
+
+
+class ExpandStringsProvider(beam.transforms.core.RestrictionProvider):
+  """A RestrictionProvider that used for sdf related tests."""
+  def initial_restriction(self, element):
+    return restriction_trackers.OffsetRange(0, len(element))
+
+  def create_tracker(self, restriction):
+    return restriction_trackers.OffsetRestrictionTracker(restriction)
+
+  def split(self, element, restriction):
+    desired_bundle_size = restriction.size() // 2
+    return restriction.split(desired_bundle_size)
+
+  def restriction_size(self, element, restriction):
+    return restriction.size()
+
+
+class UnboundedOffsetRestrictionTracker(
+    restriction_trackers.OffsetRestrictionTracker):
+  def is_bounded(self):
+    return False
+
+
+class OffsetRangeProvider(beam.transforms.core.RestrictionProvider):
+  def __init__(self, use_bounded_offset_range, checkpoint_only=False):
+    self.use_bounded_offset_range = use_bounded_offset_range
+    self.checkpoint_only = checkpoint_only
+
+  def initial_restriction(self, element):
+    return restriction_trackers.OffsetRange(0, element)
+
+  def create_tracker(self, restriction):
+    if self.checkpoint_only:
+
+      class CheckpointOnlyOffsetRestrictionTracker(
+          restriction_trackers.OffsetRestrictionTracker):
+        def try_split(self, unused_fraction_of_remainder):
+          return super().try_split(0.0)
+
+      return CheckpointOnlyOffsetRestrictionTracker(restriction)
+    if self.use_bounded_offset_range:
+      return restriction_trackers.OffsetRestrictionTracker(restriction)
+    return UnboundedOffsetRestrictionTracker(restriction)
+
+  def split(self, element, restriction):
+    return [restriction]
+
+  def restriction_size(self, element, restriction):
+    return restriction.size()
+
+
+class OffsetRangeProviderWithTruncate(OffsetRangeProvider):
+  def __init__(self):
+    super().__init__(True)
+
+  def truncate(self, element, restriction):
+    return restriction_trackers.OffsetRange(
+        restriction.start, restriction.stop // 2)
+
+
+class FnApiBasedLullLoggingTest(unittest.TestCase):
+  def create_pipeline(self):
+    return beam.Pipeline(
+        runner=fn_api_runner.FnApiRunner(
+            default_environment=environments.EmbeddedPythonGrpcEnvironment.
+            default(),
+            progress_request_frequency=0.5))
+
+
+class StateBackedTestElementType(object):
+  live_element_count = 0
+
+  def __init__(self, num_elements, unused):
+    self.num_elements = num_elements
+    StateBackedTestElementType.live_element_count += 1
+    # Due to using state backed iterable, we expect there is a few instances
+    # alive at any given time.
+    if StateBackedTestElementType.live_element_count > 5:
+      raise RuntimeError('Too many live instances.')
+
+  def __del__(self):
+    StateBackedTestElementType.live_element_count -= 1
+
+  def __reduce__(self):
+    return (self.__class__, (self.num_elements, 'x' * self.num_elements))
+
+
+@pytest.mark.it_validatesrunner
+class FnApiBasedStateBackedCoderTest(unittest.TestCase):
+  def create_pipeline(self):
+    return beam.Pipeline(
+        runner=fn_api_runner.FnApiRunner(use_state_iterables=True))
+
+  def test_gbk_many_values(self):
+    with self.create_pipeline() as p:
+      # The number of integers could be a knob to test against
+      # different runners' default settings on page size.
+      VALUES_PER_ELEMENT = 300
+      NUM_OF_ELEMENTS = 200
+
+      r = (
+          p
+          | beam.Create([None])
+          | beam.FlatMap(
+              lambda x: ((1, StateBackedTestElementType(VALUES_PER_ELEMENT, _))
+                         for _ in range(NUM_OF_ELEMENTS)))
+          | beam.GroupByKey()
+          | beam.MapTuple(lambda _, vs: sum(e.num_elements for e in vs)))
+
+      assert_that(r, equal_to([VALUES_PER_ELEMENT * NUM_OF_ELEMENTS]))
+
+
+# TODO(robertwb): Why does pickling break when this is inlined?
+class CustomMergingWindowFn(window.WindowFn):
+  def assign(self, assign_context):
+    return [
+        window.IntervalWindow(
+            assign_context.timestamp, assign_context.timestamp + 1000)
+    ]
+
+  def merge(self, merge_context):
+    evens = [w for w in merge_context.windows if w.start % 2 == 0]
+    if evens:
+      merge_context.merge(
+          evens,
+          window.IntervalWindow(
+              min(w.start for w in evens), max(w.end for w in evens)))
+
+  def get_window_coder(self):
+    return coders.IntervalWindowCoder()
+
+
+class ExpectingSideInputsFn(beam.DoFn):
+  def __init__(self, name):
+    self._name = name
+
+  def default_label(self):
+    return self._name
+
+  def process(self, element, *side_inputs):
+    logging.info('Running %s (side inputs: %s)', self._name, side_inputs)
+    if not all(list(s) for s in side_inputs):
+      raise ValueError(f'Missing data in side input {side_inputs}')
+    yield self._name
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/ray_beam_runner/portability/ray_runner_test.py
+++ b/ray_beam_runner/portability/ray_runner_test.py
@@ -148,6 +148,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       assert_that(unnamed.even, equal_to([2]), label='unnamed.even')
       assert_that(unnamed.odd, equal_to([1, 3]), label='unnamed.odd')
 
+  @unittest.skip('Side inputs not yet supported')
   def test_pardo_side_inputs(self):
     def cross_product(elem, sides):
       for side in sides:
@@ -161,6 +162,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
           equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'), ('a', 'y'), ('b', 'y'),
                     ('c', 'y')]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_pardo_side_input_dependencies(self):
     with self.create_pipeline() as p:
       inputs = [p | beam.Create([None])]
@@ -170,6 +172,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
                 ExpectingSideInputsFn(f'Do{k}'),
                 *[beam.pvalue.AsList(inputs[s]) for s in range(1, k)]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_pardo_side_input_sparse_dependencies(self):
     with self.create_pipeline() as p:
       inputs = []
@@ -190,6 +193,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
                       for s in range(1, num_inputs)
                   ]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_pardo_windowed_side_inputs(self):
     with self.create_pipeline() as p:
       # Now with some windowing.
@@ -218,6 +222,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
           ]),
           label='windowed')
 
+  @unittest.skip('Side inputs not yet supported')
   def test_flattened_side_input(self, with_transcoding=True):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create([None])
@@ -240,6 +245,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
                   equal_to([('a', 1), ('b', 2)] + third_element),
                   label='CheckFlattenOfSideInput')
 
+  @unittest.skip('Side inputs not yet supported')
   def test_gbk_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create([None])
@@ -250,6 +256,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
               'a': [1]
           })]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_multimap_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
@@ -259,6 +266,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
               lambda k, d: (k, sorted(d[k])), beam.pvalue.AsMultiMap(side)),
           equal_to([('a', [1, 3]), ('b', [2])]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_multimap_multiside_input(self):
     # A test where two transforms in the same stage consume the same PCollection
     # twice as side input.
@@ -280,6 +288,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
               beam.pvalue.AsList(side)),
           equal_to([('a', [1, 3], [1, 2, 3]), ('b', [2], [1, 2, 3])]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_multimap_side_input_type_coercion(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
@@ -294,6 +303,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
               lambda k, d: (k, sorted(d[k])), beam.pvalue.AsMultiMap(side)),
           equal_to([('a', [1, 3]), ('b', [2])]))
 
+  @unittest.skip('Side inputs not yet supported')
   def test_pardo_unfusable_side_inputs(self):
     def cross_product(elem, sides):
       for side in sides:
@@ -315,12 +325,12 @@ class RayFnApiRunnerTest(unittest.TestCase):
           pcoll | beam.FlatMap(cross_product, beam.pvalue.AsList(derived)),
           equal_to([('a', 'a'), ('a', 'b'), ('b', 'a'), ('b', 'b')]))
 
+  @unittest.skip('State not yet supported')
   def test_pardo_state_only(self):
     index_state_spec = userstate.CombiningValueStateSpec('index', sum)
     value_and_index_state_spec = userstate.ReadModifyWriteStateSpec(
         'value:index', StrUtf8Coder())
 
-    # TODO(ccy): State isn't detected with Map/FlatMap.
     class AddIndex(beam.DoFn):
       def process(
           self,
@@ -371,6 +381,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       #expected = [('fired', ts) for ts in (20, 200)]
       #assert_that(actual, equal_to(expected))
 
+  @unittest.skip('Timers not yet supported')
   def test_pardo_timers(self):
     timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
     state_spec = userstate.CombiningValueStateSpec('num_called', sum)
@@ -402,6 +413,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       expected = [('fired', ts) for ts in (20, 200, 40, 400)]
       assert_that(actual, equal_to(expected))
 
+  @unittest.skip('Timers not yet supported')
   def test_pardo_timers_clear(self):
     timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
     clear_timer_spec = userstate.TimerSpec(
@@ -437,12 +449,15 @@ class RayFnApiRunnerTest(unittest.TestCase):
       expected = [('fired', ts) for ts in (20, 200)]
       assert_that(actual, equal_to(expected))
 
+  @unittest.skip('Timers not yet supported')
   def test_pardo_state_timers(self):
     self._run_pardo_state_timers(windowed=False)
 
+  @unittest.skip('Timers not yet supported')
   def test_pardo_state_timers_non_standard_coder(self):
     self._run_pardo_state_timers(windowed=False, key_type=Any)
 
+  @unittest.skip('Timers not yet supported')
   def test_windowed_pardo_state_timers(self):
     self._run_pardo_state_timers(windowed=True)
 
@@ -511,6 +526,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
 
       assert_that(actual, is_buffered_correctly)
 
+  @unittest.skip('Timers not yet supported')
   def test_pardo_dynamic_timer(self):
     class DynamicTimerDoFn(beam.DoFn):
       dynamic_timer_spec = userstate.TimerSpec(
@@ -535,6 +551,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
           | beam.ParDo(DynamicTimerDoFn()))
       assert_that(actual, equal_to([('key1', 10), ('key2', 20), ('key3', 30)]))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf(self):
     class ExpandingStringsDoFn(beam.DoFn):
       def process(
@@ -553,6 +570,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
       assert_that(actual, equal_to(list(''.join(data))))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_dofn_as_restriction_provider(self):
     class ExpandingStringsDoFn(beam.DoFn, ExpandStringsProvider):
       def process(
@@ -568,6 +586,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
       assert_that(actual, equal_to(list(''.join(data))))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_check_done_failed(self):
     class ExpandingStringsDoFn(beam.DoFn):
       def process(
@@ -587,6 +606,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
         data = ['abc', 'defghijklmno', 'pqrstuv', 'wxyz']
         _ = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_watermark_tracking(self):
     class ExpandingStringsDoFn(beam.DoFn):
       def process(
@@ -613,6 +633,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create(data) | beam.ParDo(ExpandingStringsDoFn()))
       assert_that(actual, equal_to(list(''.join(data))))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_dofn_as_watermark_estimator(self):
     class ExpandingStringsDoFn(beam.DoFn, beam.WatermarkEstimatorProvider):
       def initial_estimator_state(self, element, restriction):
@@ -677,12 +698,15 @@ class RayFnApiRunnerTest(unittest.TestCase):
       self.assertEqual(1, len(counters))
       self.assertEqual(counters[0].committed, len(''.join(data)))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_sdf_initiated_checkpointing(self):
     self.run_sdf_initiated_checkpointing(is_drain=False)
 
+  @unittest.skip('SDF not yet supported')
   def test_draining_sdf_with_sdf_initiated_checkpointing(self):
     self.run_sdf_initiated_checkpointing(is_drain=True)
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_default_truncate_when_bounded(self):
     class SimleSDF(beam.DoFn):
       def process(
@@ -700,6 +724,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create([10]) | beam.ParDo(SimleSDF()))
       assert_that(actual, equal_to(range(10)))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_default_truncate_when_unbounded(self):
     class SimleSDF(beam.DoFn):
       def process(
@@ -717,6 +742,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       actual = (p | beam.Create([10]) | beam.ParDo(SimleSDF()))
       assert_that(actual, equal_to([]))
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_with_truncate(self):
     class SimleSDF(beam.DoFn):
       def process(
@@ -767,6 +793,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       pc = p | beam.Create(['a', 'b'])
       assert_that((pc, pc, pc) | beam.Flatten(), equal_to(['a', 'b'] * 3))
 
+  @unittest.skip('Combiner lifting not yet supported')
   def test_combine_per_key(self):
     with self.create_pipeline() as p:
       res = (
@@ -837,6 +864,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       gbk_res = (big | beam.GroupByKey() | beam.Map(lambda x: x[0]))
       assert_that(gbk_res, equal_to(['a', 'b']), label='gbk')
 
+  @unittest.skip('Error messages need to improve')
   def test_error_message_includes_stage(self):
     with self.assertRaises(BaseException) as e_cm:
       with self.create_pipeline() as p:
@@ -888,6 +916,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
       pcoll_b = p | 'b' >> beam.Create(['b'])
       assert_that((pcoll_a, pcoll_b) | First(), equal_to(['a']))
 
+  @unittest.skip('Metrics not yet supported')
   def test_metrics(self, check_gauge=True):
     p = self.create_pipeline()
 
@@ -939,6 +968,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
           | beam.ParDo(FinalizebleDoFnWithException()))
       assert_that(res, equal_to(['1', '2']))
 
+  @unittest.skip('SDF not yet supported')
   def test_register_finalizations(self):
     event_recorder = EventRecorder(tempfile.gettempdir())
 
@@ -976,6 +1006,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
 
     event_recorder.cleanup()
 
+  @unittest.skip('SDF not yet supported')
   def test_sdf_synthetic_source(self):
     common_attrs = {
         'key_size': 1,
@@ -1067,6 +1098,7 @@ class RayFnApiRunnerTest(unittest.TestCase):
         self.assertTrue(
             any(re.match(packed_step_name_regex, s) for s in step_names))
 
+  @unittest.skip('Combiners not yet supported')
   def test_pack_combiners(self):
     self._test_pack_combiners(assert_using_counter_names=True)
 
@@ -1607,6 +1639,7 @@ class FnApiRunnerSplitTest(unittest.TestCase):
       _LOGGER.error('test_split_crazy_sdf.seed = %s', seed)
       raise
 
+  @unittest.skip('SDF not yet supported')
   def test_nosplit_sdf(self):
     def split_manager(num_elements):
       yield
@@ -1616,21 +1649,27 @@ class FnApiRunnerSplitTest(unittest.TestCase):
     self.run_sdf_split_pipeline(
         split_manager, elements, ElementCounter(), expected_groups)
 
+  @unittest.skip('SDF not yet supported')
   def test_checkpoint_sdf(self):
     self.run_sdf_checkpoint(is_drain=False)
 
+  @unittest.skip('SDF not yet supported')
   def test_checkpoint_draining_sdf(self):
     self.run_sdf_checkpoint(is_drain=True)
 
+  @unittest.skip('SDF not yet supported')
   def test_split_half_sdf(self):
     self.run_sdf_split_half(is_drain=False)
 
+  @unittest.skip('SDF not yet supported')
   def test_split_half_draining_sdf(self):
     self.run_sdf_split_half(is_drain=True)
 
+  @unittest.skip('SDF not yet supported')
   def test_split_crazy_sdf(self, seed=None):
     self.run_split_crazy_sdf(seed=seed, is_drain=False)
 
+  @unittest.skip('SDF not yet supported')
   def test_split_crazy_draining_sdf(self, seed=None):
     self.run_split_crazy_sdf(seed=seed, is_drain=True)
 

--- a/ray_beam_runner/ray_runner_test.py
+++ b/ray_beam_runner/ray_runner_test.py
@@ -46,6 +46,7 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.value_provider import RuntimeValueProvider
 from apache_beam.portability import python_urns
 from ray_beam_runner import ray_runner
+from apache_beam.runners.portability.fn_api_runner import fn_runner_test
 from apache_beam.runners.sdf_utils import RestrictionTrackerView
 from apache_beam.runners.worker import data_plane
 from apache_beam.runners.worker import statesampler
@@ -82,6 +83,18 @@ def has_urn_and_labels(mi, urn, labels):
         return all(item in mi.labels.items() for item in labels.items())
 
     return contains_labels(mi, labels) and mi.urn == urn
+
+
+class RayFnRunnerTest(fn_runner_test.FnApiRunnerTest):
+    def setUp(self) -> None:
+        import ray
+        if not ray.is_initialized():
+            ray.init(local_mode=True)
+
+    def create_pipeline(self, is_drain=False):
+        return beam.Pipeline(
+            runner=ray_runner.RayRunner(),
+            options=PipelineOptions(["--parallelism=1"]))
 
 
 class RayRunnerTest(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
 from setuptools import find_packages, setup
 
+TEST_REQUIREMENTS = [
+    'pyhamcrest',
+    'pytest',
+    'tenacity',
+]
+
 setup(
     name="ray_beam",
     packages=find_packages(where=".", include="ray_beam_runner*"),
@@ -9,10 +15,15 @@ setup(
     long_description="An Apache Beam Runner based on the Ray "
     "distributed computing framework.",
     url="https://github.com/ray-project/ray_beam_runner",
-    install_requires=["ray", "apache_beam"],
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
     ],
+    install_requires=[
+        "ray[data]", "apache_beam"
+    ],
+    extras_require={
+        'test': TEST_REQUIREMENTS,
+    }
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import find_packages, setup
 
 TEST_REQUIREMENTS = [
+    'apache_beam[test]',
     'pyhamcrest',
     'pytest',
-    'tenacity',
 ]
 
 setup(


### PR DESCRIPTION
This prototype is hacked together as quickly as possible. I can't speak for its efficiency, and its code cleanliness.

Next steps:
- Enable more and more tests under `ray_runner_test.py`
- Make efficiency improvements 
    - Creation of pcollection holding actors (probably rearchitect)
    - Data transfer and encoding
    - Improve context passing (serialization and passing-around of RayRunnerExecutionContext, RayBundleContext)

Others...