### PR TITLE
add development requirements for running ray_runner_test.py

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,5 @@ flake8==3.9.1
 flake8-comprehensions
 flake8-quotes==2.0.0
 flake8-bugbear==21.9.2
+pytest==7.1.2
+pyhamcrest==2.0.3


### PR DESCRIPTION
Looks like these were still missing!
