### PR TITLE
remove instruction_id scope from RayStateManager

### DIFF
--- a/ray_beam_runner/portability/execution_test.py
+++ b/ray_beam_runner/portability/execution_test.py
@@ -43,7 +43,7 @@ class StateHandlerTest(unittest.TestCase):
             for data in StateHandlerTest.SAMPLE_INPUT_DATA:
                 sh.append_raw(StateHandlerTest.SAMPLE_STATE_KEY, data)
 
-        with sh.process_instruction_id("anyinstruction"):
+        with sh.process_instruction_id("otherinstruction"):
             continuation_token = None
             all_data = []
             while True:


### PR DESCRIPTION
As discussed in the design meeting, state should be global.