### PR TITLE
Use dynamic returns for ray_execute_bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install Ray Beam Runner
+        run: |
+          pip install -e .[test]
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -40,9 +43,6 @@ jobs:
       - name: Format
         run: |
           bash scripts/format.sh
-      - name: Install Ray Beam Runner
-        run: |
-          pip install -e .[test]
       - name: Run Portability tests
         run: |
           pytest -r A ray_beam_runner/portability/ray_runner_test.py ray_beam_runner/portability/execution_test.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,3 +7,4 @@ flake8-bugbear==21.9.2
 pytest==7.1.2
 pyhamcrest==2.0.3
 pytest-benchmark
+ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl


### PR DESCRIPTION
Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>

With dynamic returns feature, we no longer need to calculate the number of returns beforehand. 