### PR TITLE
Install ray nightly for ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
+          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
       - name: Format
         run: |
           bash scripts/format.sh

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,3 @@ flake8-bugbear==21.9.2
 pytest==7.1.2
 pyhamcrest==2.0.3
 pytest-benchmark
-ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl


### PR DESCRIPTION
Dev should install the Ray nightly of their platform manually.

Signed-off-by: Jiajun Yao <jeromeyjj@gmail.com>