### PR TITLE
Separate CI concers into different workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ on:
     branches: [ master ]
 
 jobs:
-  Build:
+
+  Code-Health:
     runs-on: ubuntu-latest
 
     steps:
@@ -44,9 +45,26 @@ jobs:
       - name: Format
         run: |
           bash scripts/format.sh
-      - name: Run Portability tests
+
+  Benchmarks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Ray Beam Runner
         run: |
-          pytest -r A ray_beam_runner/portability/ray_runner_test.py ray_beam_runner/portability/execution_test.py
+          pip install -e .[test]
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
       - name: Run Benchmark
         run: |
           pytest benchmark/simple.py --benchmark-only --benchmark-json bm-result.json
@@ -62,6 +80,32 @@ jobs:
           alert-threshold: '200%'
           comment-on-alert: true
           fail-on-alert: true
+
+  Build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Ray Beam Runner
+        run: |
+          pip install -e .[test]
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements_dev.txt
+          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+      - name: Run Portability tests
+        run: |
+          pytest -r A ray_beam_runner/portability/ray_runner_test.py ray_beam_runner/portability/execution_test.py
 
   LicenseCheck:
     name: License Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           comment-on-alert: true
           fail-on-alert: true
 
-  Build:
+  Tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,16 +85,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: [{"v":"3.8", "whl":"38"}, {"v": "3.9", "whl": "39"}, {"v": "3.10", "whl": "310"}]
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install python ${{ matrix.python-version }}
+      - name: Install python ${{ matrix.python-version.v }}
         uses: actions/setup-python@v3
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version.v }}
       - name: Install Ray Beam Runner
         run: |
           pip install -e .[test]
@@ -102,7 +102,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
+          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp${{ matrix.python-version.whl  }}-cp${{ matrix.python-version.whl}}-manylinux2014_x86_64.whl"
       - name: Run Portability tests
         run: |
           pytest -r A ray_beam_runner/portability/ray_runner_test.py ray_beam_runner/portability/execution_test.py

--- a/ray_beam_runner/translator.py
+++ b/ray_beam_runner/translator.py
@@ -335,7 +335,7 @@ class RayGroupByKey(RayDataTranslation):
         def key(windowed_value):
             if not isinstance(windowed_value, WindowedValue):
                 windowed_value = WindowedValue(windowed_value, 0,
-                                           (GlobalWindow(), ))
+                                               (GlobalWindow(), ))
 
             # Extract key from windowed value
             key, _ = windowed_value.value
@@ -345,7 +345,7 @@ class RayGroupByKey(RayDataTranslation):
         def value(windowed_value):
             if not isinstance(windowed_value, WindowedValue):
                 windowed_value = WindowedValue(windowed_value, 0,
-                                           (GlobalWindow(), ))
+                                               (GlobalWindow(), ))
 
             # Extract value from windowed value
             _, value = windowed_value.value

--- a/ray_beam_runner/translator.py
+++ b/ray_beam_runner/translator.py
@@ -17,21 +17,39 @@ from typing import Mapping, Sequence
 
 import ray.data
 
-from apache_beam import (Create, Union, ParDo, Impulse, PTransform, WindowInto,
-                         Flatten, io, DoFn)
+from apache_beam import (
+    Create,
+    Union,
+    ParDo,
+    Impulse,
+    PTransform,
+    WindowInto,
+    Flatten,
+    io,
+    DoFn,
+)
 from apache_beam.pipeline import AppliedPTransform, PipelineVisitor
 from apache_beam.pvalue import PBegin, TaggedOutput
-from apache_beam.runners.common import DoFnInvoker, \
-    DoFnSignature, DoFnContext, Receiver, _OutputProcessor
+from apache_beam.runners.common import (
+    DoFnInvoker,
+    DoFnSignature,
+    DoFnContext,
+    Receiver,
+    _OutputProcessor,
+)
 from apache_beam.transforms.sideinputs import SideInputMap
 from ray.data.block import Block, BlockMetadata, BlockAccessor
 
 from ray_beam_runner.collection import CollectionMap
 from ray_beam_runner.custom_actor_pool import CustomActorPool
-from ray_beam_runner.overrides import (_Create, _Read, _Reshuffle,
-                                       _GroupByKeyOnly, _GroupAlsoByWindow)
-from apache_beam.transforms.window import WindowFn, TimestampedValue, \
-    GlobalWindow
+from ray_beam_runner.overrides import (
+    _Create,
+    _Read,
+    _Reshuffle,
+    _GroupByKeyOnly,
+    _GroupAlsoByWindow,
+)
+from apache_beam.transforms.window import WindowFn, TimestampedValue, GlobalWindow
 from apache_beam.typehints import Optional
 from apache_beam.utils.windowed_value import WindowedValue
 
@@ -42,52 +60,54 @@ def get_windowed_value(input_item, window_fn: WindowFn):
     if isinstance(input_item, WindowedValue):
         windowed_value = input_item
     elif isinstance(input_item, TimestampedValue):
-        assign_context = WindowFn.AssignContext(input_item.timestamp,
-                                                input_item.value)
-        windowed_value = WindowedValue(input_item.value, input_item.timestamp,
-                                       window_fn.assign(assign_context))
+        assign_context = WindowFn.AssignContext(input_item.timestamp, input_item.value)
+        windowed_value = WindowedValue(
+            input_item.value, input_item.timestamp, window_fn.assign(assign_context)
+        )
     else:
-        windowed_value = WindowedValue(input_item, 0, (GlobalWindow(), ))
+        windowed_value = WindowedValue(input_item, 0, (GlobalWindow(),))
 
     return windowed_value
 
 
 class RayDataTranslation(object):
-    def __init__(self,
-                 applied_ptransform: AppliedPTransform,
-                 parallelism: int = 1):
+    def __init__(self, applied_ptransform: AppliedPTransform, parallelism: int = 1):
         self.applied_ptransform = applied_ptransform
         self.parallelism = parallelism
 
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         raise NotImplementedError
 
 
 class RayNoop(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         return ray_ds
 
 
 class RayImpulse(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is None
         return ray.data.from_items([0], parallelism=self.parallelism)
 
 
 class RayCreate(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is None
 
         original_transform: Create = self.applied_ptransform.transform
@@ -100,10 +120,11 @@ class RayCreate(RayDataTranslation):
 
 
 class RayRead(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is None
 
         original_transform: _Read = self.applied_ptransform.transform
@@ -124,19 +145,21 @@ class RayRead(RayDataTranslation):
 
 
 class RayReshuffle(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is not None
         return ray_ds.random_shuffle()
 
 
 class RayParDo(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is not None
         assert isinstance(ray_ds, ray.data.Dataset)
         assert self.applied_ptransform.transform is not None
@@ -150,8 +173,9 @@ class RayParDo(RayDataTranslation):
         kwargs = transform.kwargs or {}
 
         main_input = list(self.applied_ptransform.main_inputs.values())[0]
-        window_fn = main_input.windowing.windowfn if hasattr(
-            main_input, "windowing") else None
+        window_fn = (
+            main_input.windowing.windowfn if hasattr(main_input, "windowing") else None
+        )
 
         class TaggingReceiver(Receiver):
             def __init__(self, tag, values):
@@ -209,7 +233,8 @@ class RayParDo(RayDataTranslation):
                     args,
                     kwargs,
                     user_state_context=None,
-                    bundle_finalizer_param=self.bundle_finalizer_param)
+                    bundle_finalizer_param=self.bundle_finalizer_param,
+                )
 
             def __del__(self):
                 self.do_fn_invoker.invoke_teardown()
@@ -228,8 +253,7 @@ class RayParDo(RayDataTranslation):
                 self.values.clear()
 
                 for input_item in batch:
-                    windowed_value = get_windowed_value(
-                        input_item, self.window_fn)
+                    windowed_value = get_windowed_value(input_item, self.window_fn)
                     self.do_fn_invoker.invoke_process(windowed_value)
 
                 self.do_fn_invoker.invoke_finish_bundle()
@@ -239,8 +263,9 @@ class RayParDo(RayDataTranslation):
                 return ret
 
             @ray.method(num_returns=2)
-            def process_block(self, block: Block,
-                              meta: BlockMetadata) -> (Block, BlockMetadata):
+            def process_block(
+                self, block: Block, meta: BlockMetadata
+            ) -> (Block, BlockMetadata):
                 if not self._is_setup:
                     map_fn.setup()
                     self._is_setup = True
@@ -251,7 +276,8 @@ class RayParDo(RayDataTranslation):
                     num_rows=accessor.num_rows(),
                     size_bytes=accessor.size_bytes(),
                     schema=accessor.schema(),
-                    input_files=meta.input_files)
+                    input_files=meta.input_files,
+                )
                 return new_block, new_metadata
 
         def simple_batch_dofn(batch):
@@ -278,7 +304,8 @@ class RayParDo(RayDataTranslation):
                 args,
                 kwargs,
                 user_state_context=None,
-                bundle_finalizer_param=bundle_finalizer_param)
+                bundle_finalizer_param=bundle_finalizer_param,
+            )
 
             # Invoke setup just in case
             do_fn_invoker.invoke_setup()
@@ -307,15 +334,16 @@ class RayParDo(RayDataTranslation):
         # The lambda fn is ignored as the RayDoFnWorker encapsulates the
         # actual logic in self.process_batch
         return ray_ds.map_batches(
-            lambda batch: batch,
-            compute=CustomActorPool(worker_cls=RayDoFnWorker))
+            lambda batch: batch, compute=CustomActorPool(worker_cls=RayDoFnWorker)
+        )
 
 
 class RayGroupByKey(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is not None
         assert isinstance(ray_ds, ray.data.Dataset)
 
@@ -334,8 +362,7 @@ class RayGroupByKey(RayDataTranslation):
 
         def key(windowed_value):
             if not isinstance(windowed_value, WindowedValue):
-                windowed_value = WindowedValue(windowed_value, 0,
-                                               (GlobalWindow(), ))
+                windowed_value = WindowedValue(windowed_value, 0, (GlobalWindow(),))
 
             # Extract key from windowed value
             key, _ = windowed_value.value
@@ -344,25 +371,31 @@ class RayGroupByKey(RayDataTranslation):
 
         def value(windowed_value):
             if not isinstance(windowed_value, WindowedValue):
-                windowed_value = WindowedValue(windowed_value, 0,
-                                               (GlobalWindow(), ))
+                windowed_value = WindowedValue(windowed_value, 0, (GlobalWindow(),))
 
             # Extract value from windowed value
             _, value = windowed_value.value
             return value
 
-        return ray_ds.groupby(key).aggregate(ray.data.aggregate.AggregateFn(
-            init=lambda k: [],
-            accumulate=lambda a, r: a + [value(r)],
-            merge=lambda a1, a2: a1 + a2,
-        )).map(lambda r: (r[0].key, r[1]))
+        return (
+            ray_ds.groupby(key)
+            .aggregate(
+                ray.data.aggregate.AggregateFn(
+                    init=lambda k: [],
+                    accumulate=lambda a, r: a + [value(r)],
+                    merge=lambda a1, a2: a1 + a2,
+                )
+            )
+            .map(lambda r: (r[0].key, r[1]))
+        )
 
 
 class RayWindowInto(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         window_fn = self.applied_ptransform.transform.windowing.windowfn
 
         def to_windowed_value(item):
@@ -371,10 +404,12 @@ class RayWindowInto(RayDataTranslation):
 
             if isinstance(item, TimestampedValue):
                 return WindowedValue(
-                    item.value, item.timestamp,
+                    item.value,
+                    item.timestamp,
                     window_fn.assign(
-                        WindowFn.AssignContext(
-                            item.timestamp, element=item.value)))
+                        WindowFn.AssignContext(item.timestamp, element=item.value)
+                    ),
+                )
 
             return item
 
@@ -382,10 +417,11 @@ class RayWindowInto(RayDataTranslation):
 
 
 class RayFlatten(RayDataTranslation):
-    def apply(self,
-              ray_ds: Union[None, ray.data.Dataset, Mapping[
-                  str, ray.data.Dataset]] = None,
-              side_inputs: Optional[Sequence[ray.data.Dataset]] = None):
+    def apply(
+        self,
+        ray_ds: Union[None, ray.data.Dataset, Mapping[str, ray.data.Dataset]] = None,
+        side_inputs: Optional[Sequence[ray.data.Dataset]] = None,
+    ):
         assert ray_ds is not None
         assert isinstance(ray_ds, Mapping)
         assert len(ray_ds) >= 1
@@ -408,7 +444,7 @@ translations = {
     _GroupByKeyOnly: RayGroupByKey,
     _GroupAlsoByWindow: RayParDo,
     # CoGroupByKey: RayCoGroupByKey,
-    PTransform: RayNoop  # Todo: How to handle generic ptransforms? Map?
+    PTransform: RayNoop,  # Todo: How to handle generic ptransforms? Map?
 }
 
 
@@ -417,19 +453,18 @@ class TranslationExecutor(PipelineVisitor):
         self._collection_map = collection_map
         self._parallelism = parallelism
 
-    def enter_composite_transform(self,
-                                  transform_node: AppliedPTransform) -> None:
+    def enter_composite_transform(self, transform_node: AppliedPTransform) -> None:
         pass
 
-    def leave_composite_transform(self,
-                                  transform_node: AppliedPTransform) -> None:
+    def leave_composite_transform(self, transform_node: AppliedPTransform) -> None:
         pass
 
     def visit_transform(self, transform_node: AppliedPTransform) -> None:
         self.execute(transform_node)
 
-    def get_translation(self, applied_ptransform: AppliedPTransform
-                        ) -> Optional[RayDataTranslation]:
+    def get_translation(
+        self, applied_ptransform: AppliedPTransform
+    ) -> Optional[RayDataTranslation]:
         # Sanity check
         type_ = type(applied_ptransform.transform)
         if type_ not in translations:
@@ -437,7 +472,8 @@ class TranslationExecutor(PipelineVisitor):
 
         translation_factory = translations[type_]
         translation = translation_factory(
-            applied_ptransform, parallelism=self._parallelism)
+            applied_ptransform, parallelism=self._parallelism
+        )
 
         return translation
 
@@ -481,9 +517,11 @@ class TranslationExecutor(PipelineVisitor):
             side_ds = self._collection_map.get(side_input.pvalue)
             side_inputs.append(
                 SideInputMap(
-                    type(side_input), side_input._view_options(),
-                    RayDatasetAccessor(side_ds,
-                                       side_input._window_mapping_fn)))
+                    type(side_input),
+                    side_input._view_options(),
+                    RayDatasetAccessor(side_ds, side_input._window_mapping_fn),
+                )
+            )
 
         def _visualize(ray_ds_dict):
             for name, ray_ds in ray_ds_dict.items():
@@ -527,8 +565,9 @@ class TranslationExecutor(PipelineVisitor):
             if out:
                 if name != "None":
                     # Side output
-                    out = out.filter(lambda x: isinstance(x, TaggedOutput) and
-                                     x.tag == name)
+                    out = out.filter(
+                        lambda x: isinstance(x, TaggedOutput) and x.tag == name
+                    )
                     out = out.map(lambda x: x.value)
                 else:
                     # Main output

--- a/ray_beam_runner/util.py
+++ b/ray_beam_runner/util.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import ray
 
 from apache_beam.pipeline import PipelineVisitor
+
 
 class PipelinePrinter(PipelineVisitor):
     def visit_value(self, value, producer_node):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,6 +4,7 @@ flake8==3.9.1
 flake8-comprehensions
 flake8-quotes==2.0.0
 flake8-bugbear==21.9.2
+pylint==2.15.4
 pytest==7.1.2
 pyhamcrest==2.0.3
 pytest-benchmark

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -94,6 +94,7 @@ format_changed() {
 format_all() {
     black ray_beam_runner/
     flake8 --config=.flake8 ray_beam_runner
+    pylint ray_beam_runner/
 }
 
 # This flag formats individual files. --files *must* be the first command line


### PR DESCRIPTION
This PR does the following:

- Fixes flake8 checks for the whole repo (I think)
- Adds pylint checks for the whole repo (these are currently failing)
- Separates the Build workflow into:
  - Code health: Formatting, lint, flake8
  - Benchmakrs: Run benchmarks and store results
  - Build for Python 3.8, 3.9, 3.10: Run unit tests 
 
This way we can separate some concerns.