### PR TITLE
chore: removes Ray nightly from dependency in favor of 2.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl"
       - name: Format
         run: |
           bash scripts/format.sh

--- a/README.md
+++ b/README.md
@@ -35,13 +35,6 @@ functionality exist in the file `ray_beam_runner/portability/ray_runner_test.py`
 
 ```shell
 pytest ray_beam_runner/portability/ray_runner_test.py
-
-# If saw error messages like "TypeError: The type of keyword 'num_returns' must be (<class 'int'>, <class 'NoneType'>), but received type <class 'str'>"
-# pick the nightly release works for your platform: https://docs.ray.io/en/latest/ray-overview/installation.html#daily-releases-nightlies
-# try to install ray nightly locally, for example:
-pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp39-cp39-manylinux2014_x86_64.whl"
-# and re-run:
-pytest ray_beam_runner/portability/ray_runner_test.py
 ```
 
 To run all local unit tests, you can simply run `pytest` from the root directory.


### PR DESCRIPTION
This change removes the nightly dependency from ci setup (from this commit: https://github.com/ray-project/ray_beam_runner/commit/b3c363657ec29faec65445f539b07605f7c07001) along with the dev instructions (from this commit: https://github.com/ray-project/ray_beam_runner/commit/754570b79af785145b32b19a1244d9482fb8733e).