### PR TITLE
Register protobuf serializers

### DIFF
--- a/ray_beam_runner/portability/ray_fn_runner.py
+++ b/ray_beam_runner/portability/ray_fn_runner.py
@@ -53,6 +53,7 @@ from ray_beam_runner.portability.execution import (
     merge_stage_results,
 )
 from ray_beam_runner.portability.execution import RayRunnerExecutionContext
+from ray_beam_runner.serialization import register_protobuf_serializers
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -198,6 +199,7 @@ class RayFnApiRunner(runner.PipelineRunner):
         """Execute pipeline represented by a list of stages and a context."""
         logging.info("Starting pipeline of %d stages." % len(stages))
 
+        register_protobuf_serializers()
         runner_execution_context = RayRunnerExecutionContext(
             stages,
             stage_context.components,
@@ -328,9 +330,7 @@ class RayFnApiRunner(runner.PipelineRunner):
             },
         )
         result_generator = iter(ray.get(result_generator_ref))
-        result = beam_fn_api_pb2.InstructionResponse.FromString(
-            ray.get(next(result_generator))
-        )
+        result = ray.get(next(result_generator))
 
         output = []
         num_outputs = ray.get(next(result_generator))

--- a/ray_beam_runner/serialization.py
+++ b/ray_beam_runner/serialization.py
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import ray
 
 from apache_beam.portability.api import beam_runner_api_pb2, beam_fn_api_pb2

--- a/ray_beam_runner/serialization.py
+++ b/ray_beam_runner/serialization.py
@@ -1,0 +1,29 @@
+import ray
+
+from apache_beam.portability.api import beam_runner_api_pb2, beam_fn_api_pb2
+
+
+def register_protobuf_serializers():
+    """
+    Register serializers for protobuf messages.
+    Note: Serializers are managed locally for each Ray worker.
+    """
+    # TODO(rkenmi): Figure out how to not repeat this call on workers?
+    pb_msg_map = {
+        msg_name: pb_module
+        for pb_module in [beam_fn_api_pb2, beam_runner_api_pb2]
+        for msg_name in pb_module.DESCRIPTOR.message_types_by_name.keys()
+    }
+
+    def _serializer(message):
+        return message.SerializeToString()
+
+    def _deserializer(pb_module, msg_name):
+        return lambda s: getattr(pb_module, msg_name).FromString(s)
+
+    for msg_name, pb_module in pb_msg_map.items():
+        ray.util.register_serializer(
+            getattr(pb_module, msg_name),
+            serializer=_serializer,
+            deserializer=_deserializer(pb_module, msg_name),
+        )


### PR DESCRIPTION
For #29 

Favor usage of `ray.util.register_serializers` to handle Protobuf message serialization