### PR TITLE
Remove Ray nightly in CI and adopt locked version for repro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements_dev.txt
-          pip install -U "ray @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp${{ matrix.python-version.whl  }}-cp${{ matrix.python-version.whl}}-manylinux2014_x86_64.whl"
       - name: Run Portability tests
         run: |
           pytest -r A ray_beam_runner/portability/ray_runner_test.py ray_beam_runner/portability/execution_test.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,3 +9,4 @@ pytest==7.1.2
 pyhamcrest==2.0.3
 pytest-benchmark
 apache-beam==2.42.0
+ray==2.5.1


### PR DESCRIPTION
- Update dev requirements
  - Lock Ray version for better reproducibility
- Update CI config
  - Remove Ray nightly install in CI to use locked version from dev requirements 

pytest execution: 51 passed, 14 skipped